### PR TITLE
회원가입(회원 등록) 서비스 로직 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+**/.DS_Store
 
 ### STS ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,9 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/upstage/devup/auth/config/SecurityConfig.java
+++ b/src/main/java/com/upstage/devup/auth/config/SecurityConfig.java
@@ -1,0 +1,16 @@
+package com.upstage.devup.auth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/com/upstage/devup/auth/domain/dto/SignUpRequestDto.java
+++ b/src/main/java/com/upstage/devup/auth/domain/dto/SignUpRequestDto.java
@@ -1,0 +1,26 @@
+package com.upstage.devup.auth.domain.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignUpRequestDto {
+
+    @NotBlank(message = "아이디는 필수 항목입니다.")
+    private String loginId;
+
+    @NotBlank(message = "비밀번호는 필수 항목입니다.")
+    private String password;
+
+    @NotBlank(message = "닉네임은 필수 항목입니다.")
+    private String nickname;
+
+    @Email(message = "이메일 형식이 아닙니다.")
+    private String email;
+
+}

--- a/src/main/java/com/upstage/devup/auth/domain/dto/SignUpResponseDto.java
+++ b/src/main/java/com/upstage/devup/auth/domain/dto/SignUpResponseDto.java
@@ -1,0 +1,19 @@
+package com.upstage.devup.auth.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignUpResponseDto {
+
+    private Long id;
+    private String loginId;
+    private String nickname;
+    private String email;
+
+}

--- a/src/main/java/com/upstage/devup/auth/domain/entity/User.java
+++ b/src/main/java/com/upstage/devup/auth/domain/entity/User.java
@@ -1,0 +1,39 @@
+package com.upstage.devup.auth.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "users")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "login_id", nullable = false, unique = true)
+    private String loginId;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false, unique = true)
+    private String nickname;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/upstage/devup/auth/domain/mapper/UserMapper.java
+++ b/src/main/java/com/upstage/devup/auth/domain/mapper/UserMapper.java
@@ -1,0 +1,37 @@
+package com.upstage.devup.auth.domain.mapper;
+
+import com.upstage.devup.auth.domain.dto.SignUpRequestDto;
+import com.upstage.devup.auth.domain.dto.SignUpResponseDto;
+import com.upstage.devup.auth.domain.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class UserMapper {
+
+    private final PasswordEncoder passwordEncoder;
+
+    public User toEntity(SignUpRequestDto request) {
+
+        return User.builder()
+                .loginId(request.getLoginId())
+                .password(passwordEncoder.encode(request.getPassword()))
+                .nickname(request.getNickname())
+                .email(request.getEmail())
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    public SignUpResponseDto toSignUpResponseDto(User entity) {
+        return SignUpResponseDto.builder()
+                .id(entity.getId())
+                .loginId(entity.getLoginId())
+                .nickname(entity.getNickname())
+                .email(entity.getEmail())
+                .build();
+    }
+}

--- a/src/main/java/com/upstage/devup/auth/respository/UserRepository.java
+++ b/src/main/java/com/upstage/devup/auth/respository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.upstage.devup.auth.respository;
+
+import com.upstage.devup.auth.domain.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    boolean existsByLoginId(String loginId);
+
+    boolean existsByNickname(String nickname);
+
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/com/upstage/devup/auth/service/UserService.java
+++ b/src/main/java/com/upstage/devup/auth/service/UserService.java
@@ -1,0 +1,78 @@
+package com.upstage.devup.auth.service;
+
+import com.upstage.devup.auth.domain.dto.SignUpRequestDto;
+import com.upstage.devup.auth.domain.dto.SignUpResponseDto;
+import com.upstage.devup.auth.domain.entity.User;
+import com.upstage.devup.auth.domain.mapper.UserMapper;
+import com.upstage.devup.auth.respository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final UserMapper userMapper;
+
+    /**
+     * 회원가입
+     *
+     * @param request 회원가입 요청 정보
+     * @return 회원가입 결과
+     */
+    public SignUpResponseDto signUp(SignUpRequestDto request) {
+        if (request == null) {
+            return null;
+        }
+
+        // 중복 검사
+        if (isLoginIdInUse(request.getLoginId())) {
+            return null;
+        }
+
+        if (isNicknameInUse(request.getNickname())) {
+            return null;
+        }
+
+        if (isEmailInUse(request.getEmail())) {
+            return null;
+        }
+
+        User savedEntity = userRepository.save(userMapper.toEntity(request));
+
+        return userMapper.toSignUpResponseDto(savedEntity);
+    }
+
+    /**
+     * 로그인 ID가 사용 중인지 확인
+     *
+     * @param loginId 확인할 로그인 ID
+     * @return true: 이미 사용 중, false: 사용 가능
+     */
+    public boolean isLoginIdInUse(String loginId) {
+        return userRepository.existsByLoginId(loginId);
+    }
+
+    /**
+     * 닉네임이 사용 중인지 확인
+     *
+     * @param nickname 확인할 닉네임
+     * @return true: 이미 사용 중, false: 사용 가능
+     */
+    public boolean isNicknameInUse(String nickname) {
+        return userRepository.existsByNickname(nickname);
+    }
+
+    /**
+     * 이메일이 사용 중인지 확인
+     *
+     * @param email 확인할 이메일
+     * @return true: 이미 사용 중, false: 사용 가능
+     */
+    public boolean isEmailInUse(String email) {
+        return userRepository.existsByEmail(email);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
     activate:
       on-profile: dev
   datasource:
-    url: jdbc:h2:mem:devup;
+    url: jdbc:h2:mem:devup;MODE=MySQL;
     driver-class-name: org.h2.Driver
     username: sa
     password:
@@ -26,6 +26,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        dialect: org.hibernate.dialect.MySQL8Dialect
   sql:
     init:
       mode: always

--- a/src/test/java/com/upstage/devup/auth/service/UserServiceTest.java
+++ b/src/test/java/com/upstage/devup/auth/service/UserServiceTest.java
@@ -1,0 +1,118 @@
+package com.upstage.devup.auth.service;
+
+import com.upstage.devup.auth.domain.dto.SignUpRequestDto;
+import com.upstage.devup.auth.domain.dto.SignUpResponseDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class UserServiceTest {
+
+    @Autowired
+    private UserService userService;
+
+    private String loginId = "qwerty";
+    private String password = "asdf1234";
+    private String nickname = "apple";
+    private String email = "apple@gmail.com";
+
+    @Test
+    @DisplayName("회원가입 성공")
+    public void successToSignUp() {
+        // given
+        SignUpRequestDto request = SignUpRequestDto.builder()
+                .loginId(loginId)
+                .password(password)
+                .nickname(nickname)
+                .email(email)
+                .build();
+
+        // when
+        SignUpResponseDto result = userService.signUp(request);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isGreaterThan(0);
+        assertThat(result.getLoginId()).isEqualTo(loginId);
+        assertThat(result.getNickname()).isEqualTo(nickname);
+        assertThat(result.getEmail()).isEqualTo(email);
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 - 요청 데이터가 null인 경우")
+    public void failToSignUpUsingNullRequest() {
+        // given
+        SignUpRequestDto request = null;
+
+        // when
+        SignUpResponseDto result = userService.signUp(request);
+
+        // then
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 - 중복된 로그인 ID로 가입하려는 경우")
+    public void failToSignUpUsingUsedLoginId() {
+        // given
+        String usedLoginId = "user1";
+
+        SignUpRequestDto request = SignUpRequestDto.builder()
+                .loginId(usedLoginId)
+                .password(password)
+                .nickname(nickname)
+                .email(email)
+                .build();
+
+        // when
+        SignUpResponseDto result = userService.signUp(request);
+
+        // then
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 - 중복된 닉네임로 가입하려는 경우")
+    public void failToSignUpUsingUsedNickname() {
+        // given
+        String usedNickname = "개발자1";
+
+        SignUpRequestDto request = SignUpRequestDto.builder()
+                .loginId(loginId)
+                .password(password)
+                .nickname(usedNickname)
+                .email(email)
+                .build();
+
+        // when
+        SignUpResponseDto result = userService.signUp(request);
+
+        // then
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 - 중복된 이메일로 가입하려는 경우")
+    public void failToSignUpUsingUsedEmail() {
+        // given
+        String usedEmail = "admin@devup.com";
+
+        SignUpRequestDto request = SignUpRequestDto.builder()
+                .loginId(loginId)
+                .password(password)
+                .nickname(nickname)
+                .email(usedEmail)
+                .build();
+
+        // when
+        SignUpResponseDto result = userService.signUp(request);
+
+        // then
+        assertThat(result).isNull();
+    }
+
+}


### PR DESCRIPTION
## 작업 내용
- validation 및 Spring Security 의존성 추가
- application.yml 설정 추가
  - Hibernate Dialect를 MySQL8Dialect로 명시
  - JDBC URL에 MODE=MySQL 설정을 추가해 MySQL 호환성 확보
- 회원 등록 서비스 로직 구현
- 로그인 ID, 닉네임, 이메일 중복 검사 기능 추가
- 회원가입 관련 테스트 코드 작성 및 통과 확인