### PR TITLE
면접 질문 조회 시 예외 처리 추가(EntityNotFoundException)

### DIFF
--- a/src/main/java/com/upstage/devup/global/exception/EntityNotFoundException.java
+++ b/src/main/java/com/upstage/devup/global/exception/EntityNotFoundException.java
@@ -1,0 +1,7 @@
+package com.upstage.devup.global.exception;
+
+public class EntityNotFoundException extends RuntimeException {
+    public EntityNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/upstage/devup/question/service/BoardService.java
+++ b/src/main/java/com/upstage/devup/question/service/BoardService.java
@@ -1,5 +1,6 @@
 package com.upstage.devup.question.service;
 
+import com.upstage.devup.global.exception.EntityNotFoundException;
 import com.upstage.devup.question.domain.dto.QuestionDetailDto;
 import com.upstage.devup.question.domain.entity.Question;
 import com.upstage.devup.question.repository.BoardRepository;
@@ -11,8 +12,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -26,6 +25,7 @@ public class BoardService {
 
     /**
      * 면접 질문 목록 조회
+     *
      * @param page 페이지 번호
      * @return 조회된 면접 질문 목록
      */
@@ -42,8 +42,9 @@ public class BoardService {
 
     /**
      * 제목으로 면접 질문 목록 조회
+     *
      * @param title 검색할 제목
-     * @param page 페이지 번호
+     * @param page  페이지 번호
      * @return 조회된 면접 질문 목록
      */
     public List<QuestionDetailDto> searchQuestionsByTitle(String title, int page) {
@@ -68,17 +69,15 @@ public class BoardService {
 
     /**
      * 면접 질문 상세 조회
+     *
      * @param id 면접 질문 ID
      * @return 면접 질문 상세 정보
      */
-    public QuestionDetailDto findById(Long id) {
-        Optional<Question> optional = boardRepository.findById(id);
-
-        if (optional.isEmpty()) {
-            return null;
-        }
-
-        return convertQuestionToDetailDto(optional.get());
+    public QuestionDetailDto getQuestion(Long id) {
+        return boardRepository
+                .findById(id)
+                .map(this::convertQuestionToDetailDto)
+                .orElseThrow(() -> new EntityNotFoundException("면접 질문을 찾을 수 없습니다."));
     }
 
     /**

--- a/src/test/java/com/upstage/devup/question/service/BoardServiceTest.java
+++ b/src/test/java/com/upstage/devup/question/service/BoardServiceTest.java
@@ -1,5 +1,6 @@
 package com.upstage.devup.question.service;
 
+import com.upstage.devup.global.exception.EntityNotFoundException;
 import com.upstage.devup.question.domain.dto.QuestionDetailDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 class BoardServiceTest {
@@ -82,22 +84,25 @@ class BoardServiceTest {
         Long questionId = 1L;
 
         // when
-        QuestionDetailDto result = boardService.findById(questionId);
+        QuestionDetailDto result = boardService.getQuestion(questionId);
 
         // then
         assertThat(result.getId()).isEqualTo(questionId);
     }
 
     @Test
-    @DisplayName("면접 질문 조회 - 유효하지 않은 ID로 조회 시 실패")
-    public void failToFindQuestionById() {
+    @DisplayName("면접 질문 조회 실패 - 유효하지 않은 ID로 조회하는 경우(EntityNotFoundException 반환)")
+    public void failToGetQuestion_whenUsingInvalidId() {
         // given
-        Long questionId = -1L;
+        Long questionId = 0L;
+        String errorMessage = "면접 질문을 찾을 수 없습니다.";
 
-        // when
-        QuestionDetailDto dto = boardService.findById(questionId);
+        // when & then
+        EntityNotFoundException exception = assertThrows(
+                EntityNotFoundException.class,
+                () -> boardService.getQuestion(questionId)
+        );
 
-        // then
-        assertThat(dto).isNull();
+        assertThat(exception.getMessage()).isEqualTo(errorMessage);
     }
 }


### PR DESCRIPTION
## 작업 내용
- 면접 질문 조회 시 값이 없는 경우 `EntityNotFoundException` 예외 발생
- 전역 예외 처리 필터는 아직 적용하지 않음

## 참고 사항
- EntityNotFoundException 클래스는 재사용을 위해 `global/exception` 패키지에 위치