### PR TITLE
정답 조회 시 예외 처리 추가

### DIFF
--- a/src/main/java/com/upstage/devup/answer/service/AnswerService.java
+++ b/src/main/java/com/upstage/devup/answer/service/AnswerService.java
@@ -3,6 +3,7 @@ package com.upstage.devup.answer.service;
 import com.upstage.devup.answer.domain.dto.AnswerDetailDto;
 import com.upstage.devup.answer.domain.entity.Answer;
 import com.upstage.devup.answer.repository.AnswerRepository;
+import com.upstage.devup.global.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -15,19 +16,21 @@ public class AnswerService {
     private final AnswerRepository answerRepository;
 
     /**
-     * 정답 조회
+     * 면접 질문 ID에 해당하는 정답 조회
      * @param questionId 면접 질문 ID
      * @return 조회된 정답
+     * @throws IllegalArgumentException questionId가 null인 경우 발생
+     * @throws EntityNotFoundException 조회 결과가 없는 경우 발생
      */
     public AnswerDetailDto getAnswerByQuestionId(Long questionId) {
         if (questionId == null) {
-            return null;
+            throw new IllegalArgumentException("유효하지 않은 ID입니다.");
         }
 
         return answerRepository
                 .findByQuestion_Id(questionId)
                 .map(this::convertAnswerToAnswerDetailDto)
-                .orElse(null);
+                .orElseThrow(() -> new EntityNotFoundException("정답을 찾을 수 없습니다."));
     }
 
     private AnswerDetailDto convertAnswerToAnswerDetailDto(Answer answer) {

--- a/src/test/java/com/upstage/devup/answer/service/AnswerServiceTest.java
+++ b/src/test/java/com/upstage/devup/answer/service/AnswerServiceTest.java
@@ -1,0 +1,64 @@
+package com.upstage.devup.answer.service;
+
+import com.upstage.devup.answer.domain.dto.AnswerDetailDto;
+import com.upstage.devup.global.exception.EntityNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+class AnswerServiceTest {
+
+    @Autowired
+    private AnswerService answerService;
+
+    @Test
+    @DisplayName("면접 질문에 해당하는 정답 조회 성공")
+    public void shouldReturnAnswer_whenQuestionIdIsValid() {
+        // given
+        Long questionId = 1L;
+
+        // when
+        AnswerDetailDto result = answerService.getAnswerByQuestionId(questionId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getQuestionId()).isEqualTo(questionId);
+    }
+
+    @Test
+    @DisplayName("정답 조회 실패 - null로 조회하는 경우 IllegalArgumentException 발생")
+    public void shouldThrowIllegalArgumentException_whenQuestionIdIsNull() {
+        // given
+        Long questionId = null;
+        String errorMessage = "유효하지 않은 ID입니다.";
+
+        // when & then
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> answerService.getAnswerByQuestionId(questionId)
+        );
+
+        assertThat(exception.getMessage()).isEqualTo(errorMessage);
+    }
+
+    @Test
+    @DisplayName("정답 조회 실패 - 저장된 정답이 없는 경우 EntityNotFoundException 발생")
+    public void shouldThrowEntityNotFoundException_whenAnswerIsNotFound() {
+        // given
+        Long questionId = Long.MAX_VALUE;
+        String errorMessage = "정답을 찾을 수 없습니다.";
+
+        // when & then
+        EntityNotFoundException exception = assertThrows(
+                EntityNotFoundException.class,
+                () -> answerService.getAnswerByQuestionId(questionId)
+        );
+
+        assertThat(exception.getMessage()).isEqualTo(errorMessage);
+    }
+}


### PR DESCRIPTION
## 작업 내용
- null ID로 조회 시 `IllegalArgumentException` 발생
- 저장된 정답이 없는 경우 `EntityNotFoundException` 발생
- 관련 테스트 코드 작성 및 통과 확인