### PR TITLE
fix: 제목으로 질문 검색 시 발생하는 ESCAPE 오류 해결

### DIFF
--- a/src/main/java/com/upstage/devup/question/repository/BoardRepository.java
+++ b/src/main/java/com/upstage/devup/question/repository/BoardRepository.java
@@ -4,12 +4,23 @@ import com.upstage.devup.question.domain.entity.Question;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.List;
+import org.springframework.data.jpa.repository.Query;
 
 public interface BoardRepository extends JpaRepository<Question, Long> {
 
     Page<Question> findAll(Pageable pageable);
 
+    @Query(
+            value = """
+                SELECT *
+                FROM questions q
+                WHERE UPPER(q.title) LIKE UPPER(CONCAT('%', :title, '%'))
+                ORDER BY q.id DESC
+            """, countQuery = """
+                SELECT COUNT(*)
+                FROM questions q
+                WHERE UPPER(q.title) LIKE UPPER(CONCAT('%', :title, '%'))
+            """, nativeQuery = true
+    )
     Page<Question> findByTitleContainsIgnoreCase(String title, Pageable pageable);
 }

--- a/src/main/java/com/upstage/devup/question/service/BoardService.java
+++ b/src/main/java/com/upstage/devup/question/service/BoardService.java
@@ -6,6 +6,7 @@ import com.upstage.devup.question.domain.entity.Question;
 import com.upstage.devup.question.repository.BoardRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -47,24 +48,23 @@ public class BoardService {
      * @param page  페이지 번호
      * @return 조회된 면접 질문 목록
      */
-    public List<QuestionDetailDto> searchQuestionsByTitle(String title, int page) {
+    public Page<QuestionDetailDto> searchQuestionsByTitle(String title, int page) {
         if (title == null) {
-            return List.of();
+            return Page.empty();
         }
 
         String str = title.trim();
 
         if (str.length() < 2) {
-            return List.of();
+            return Page.empty();
         }
 
         Sort sort = Sort.by(Sort.Direction.DESC, "id");
         Pageable pageable = PageRequest.of(page, QUESTIONS_PER_PAGE, sort);
 
-        return boardRepository.findByTitleContainsIgnoreCase(str, pageable)
-                .stream()
-                .map(this::convertQuestionToDetailDto)
-                .collect(Collectors.toList());
+        return boardRepository
+                .findByTitleContainsIgnoreCase(str, pageable)
+                .map(this::convertQuestionToDetailDto);
     }
 
     /**

--- a/src/test/java/com/upstage/devup/question/service/BoardServiceTest.java
+++ b/src/test/java/com/upstage/devup/question/service/BoardServiceTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -42,10 +43,10 @@ class BoardServiceTest {
         int page = 0;
 
         // when
-        List<QuestionDetailDto> results = boardService.searchQuestionsByTitle(title, page);
+        Page<QuestionDetailDto> results = boardService.searchQuestionsByTitle(title, page);
 
         // then
-        assertThat(results.size()).isGreaterThan(0);
+        assertThat(results.getTotalElements()).isGreaterThan(0);
     }
 
     @Test
@@ -56,10 +57,10 @@ class BoardServiceTest {
         int page = 0;
 
         // when
-        List<QuestionDetailDto> results = boardService.searchQuestionsByTitle(title, page);
+        Page<QuestionDetailDto> results = boardService.searchQuestionsByTitle(title, page);
 
         // then
-        assertThat(results.size()).isEqualTo(0);
+        assertThat(results.getTotalElements()).isEqualTo(0);
     }
 
     @Test
@@ -70,10 +71,10 @@ class BoardServiceTest {
         int page = 0;
 
         // when
-        List<QuestionDetailDto> results = boardService.searchQuestionsByTitle(title, page);
+        Page<QuestionDetailDto> results = boardService.searchQuestionsByTitle(title, page);
 
         // then
-        assertThat(results.size()).isEqualTo(0);
+        assertThat(results.getTotalElements()).isEqualTo(0);
     }
 
     @Transactional


### PR DESCRIPTION
## 작업 내용
- `findByTitleContainsIgnoreCase` 사용 시 H2에서 `LIKE ESCAPE \\\\` 관련 오류 발생
- `@Query`를 사용해 Hibernate가 자동 생성하던 ESCAPE 구문을 제거한 SQL문 사용으로 문제 해결
- 반환 결과를 `List<T>`에서 `Page<T>`를 반환하도록 수정