### PR TITLE
feat: 로그인 화면 구현

### DIFF
--- a/src/main/java/com/upstage/devup/auth/config/SecurityConfig.java
+++ b/src/main/java/com/upstage/devup/auth/config/SecurityConfig.java
@@ -16,7 +16,7 @@ public class SecurityConfig {
     };
 
     public static final String[] PUBLIC_PAGES = {
-            "/", "/questions/**", "/api/answers/**"
+            "/", "/auth/signup", "/questions/**", "/api/answers/**"
     };
 
     @Bean

--- a/src/main/java/com/upstage/devup/auth/config/SecurityConfig.java
+++ b/src/main/java/com/upstage/devup/auth/config/SecurityConfig.java
@@ -1,9 +1,11 @@
 package com.upstage.devup.auth.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -22,8 +24,12 @@ public class SecurityConfig {
     };
 
     public static final String[] PUBLIC_APIS = {
-            "/api/answers/**"
+            "/api/answers/**",
+            "/api/auth/signin"
     };
+
+    @Value("${security.csrf-enabled:true}")
+    private boolean csrfEnabled;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -32,6 +38,10 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        if (!csrfEnabled) {
+//            http.csrf(csrf -> csrf.disable());
+            http.csrf(AbstractHttpConfigurer::disable);
+        }
         http
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(STATIC_RESOURCES).permitAll()

--- a/src/main/java/com/upstage/devup/auth/config/SecurityConfig.java
+++ b/src/main/java/com/upstage/devup/auth/config/SecurityConfig.java
@@ -16,7 +16,13 @@ public class SecurityConfig {
     };
 
     public static final String[] PUBLIC_PAGES = {
-            "/", "/auth/signup", "/questions/**", "/api/answers/**"
+            "/",
+            "/auth/signup", "/auth/signin",
+            "/questions/**"
+    };
+
+    public static final String[] PUBLIC_APIS = {
+            "/api/answers/**"
     };
 
     @Bean
@@ -30,6 +36,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(STATIC_RESOURCES).permitAll()
                         .requestMatchers(PUBLIC_PAGES).permitAll()
+                        .requestMatchers(PUBLIC_APIS).permitAll()
                         .anyRequest().authenticated()
                 )
                 .formLogin(Customizer.withDefaults())

--- a/src/main/java/com/upstage/devup/auth/controller/SignInController.java
+++ b/src/main/java/com/upstage/devup/auth/controller/SignInController.java
@@ -1,0 +1,32 @@
+package com.upstage.devup.auth.controller;
+
+import com.upstage.devup.auth.domain.dto.SignInRequestDto;
+import com.upstage.devup.auth.domain.dto.SignInResponseDto;
+import com.upstage.devup.auth.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth/signin")
+@RequiredArgsConstructor
+public class SignInController {
+
+    private final UserService userService;
+
+    /**
+     * 로그인
+     *
+     * @param request 로그인 요청 데이터
+     * @return 로그인 결과
+     */
+    @PostMapping
+    public ResponseEntity<?> signIn(@RequestBody @Valid SignInRequestDto request) {
+        SignInResponseDto result = userService.signIn(request);
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/com/upstage/devup/auth/domain/dto/SignInResponseDto.java
+++ b/src/main/java/com/upstage/devup/auth/domain/dto/SignInResponseDto.java
@@ -1,0 +1,20 @@
+package com.upstage.devup.auth.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SignInResponseDto {
+
+    private String token;
+
+    private Long userId;
+    private String loginId;
+    private String nickname;
+
+    private String redirectUrl;
+
+}

--- a/src/main/java/com/upstage/devup/auth/service/UserService.java
+++ b/src/main/java/com/upstage/devup/auth/service/UserService.java
@@ -2,6 +2,7 @@ package com.upstage.devup.auth.service;
 
 import com.upstage.devup.auth.config.jwt.JwtTokenProvider;
 import com.upstage.devup.auth.domain.dto.SignInRequestDto;
+import com.upstage.devup.auth.domain.dto.SignInResponseDto;
 import com.upstage.devup.auth.domain.dto.SignUpRequestDto;
 import com.upstage.devup.auth.domain.dto.SignUpResponseDto;
 import com.upstage.devup.auth.domain.entity.User;
@@ -33,7 +34,7 @@ public class UserService {
      * @throws IllegalArgumentException 요청 데이터가 null일 때 발생
      * @throws InvalidLoginException 아이디 또는 비밀번호가 일치하지 않는 경우 발생
      */
-    public String signIn(SignInRequestDto request) {
+    public SignInResponseDto signIn(SignInRequestDto request) {
         if (request == null) {
             throw new IllegalArgumentException("유효하지 않는 요청입니다.");
         }
@@ -50,7 +51,15 @@ public class UserService {
         }
 
         // JWT 발급
-        return jwtTokenProvider.generateToken(user.getId());
+        String token = jwtTokenProvider.generateToken(user.getId());
+
+        return SignInResponseDto.builder()
+                .token(token)
+                .userId(user.getId())
+                .loginId(user.getLoginId())
+                .nickname(user.getNickname())
+                .redirectUrl("/")
+                .build();
     }
 
     /**

--- a/src/main/java/com/upstage/devup/global/domain/dto/ErrorResponse.java
+++ b/src/main/java/com/upstage/devup/global/domain/dto/ErrorResponse.java
@@ -1,0 +1,6 @@
+package com.upstage.devup.global.domain.dto;
+
+public record ErrorResponse(String code, String message) {
+
+}
+

--- a/src/main/java/com/upstage/devup/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/upstage/devup/global/handler/GlobalExceptionHandler.java
@@ -1,0 +1,19 @@
+package com.upstage.devup.global.handler;
+
+import com.upstage.devup.auth.exception.InvalidLoginException;
+import com.upstage.devup.global.domain.dto.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(InvalidLoginException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidLogin(InvalidLoginException e) {
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(new ErrorResponse("INVALID_LOGIN", e.getMessage()));
+    }
+}

--- a/src/main/java/com/upstage/devup/web/AuthViewController.java
+++ b/src/main/java/com/upstage/devup/web/AuthViewController.java
@@ -12,4 +12,9 @@ public class AuthViewController {
     public String getSignupPage() {
         return "auth/signup";
     }
+
+    @GetMapping("/signin")
+    public String getSigninPage() {
+        return "auth/signin";
+    }
 }

--- a/src/main/java/com/upstage/devup/web/AuthViewController.java
+++ b/src/main/java/com/upstage/devup/web/AuthViewController.java
@@ -1,0 +1,15 @@
+package com.upstage.devup.web;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/auth")
+public class AuthViewController {
+
+    @GetMapping("/signup")
+    public String getSignupPage() {
+        return "auth/signup";
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,6 +42,9 @@ jwt:
   issuer: ${JWT_ISSUER}
   expiration: ${JWT_EXPIRATION}
 
+security:
+  csrf-enabled: false
+
 
 ---
 
@@ -49,3 +52,6 @@ spring:
   config:
     activate:
       on-profile: prod
+
+security:
+  csrf-enabled: true

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -20,10 +20,10 @@ VALUES
 INSERT INTO users
     (id, login_id, password, nickname, email, created_at)
 VALUES
-    (1, 'user1', 'pass1111', '개발자1', 'user1@devup.com', CURRENT_TIMESTAMP),
-    (2, 'user2', 'pass2222', '개발자2', 'user2@devup.com', CURRENT_TIMESTAMP),
-    (3, 'user3', 'pass3333', '개발자3', 'user3@devup.com', CURRENT_TIMESTAMP),
-    (4, 'admin', 'admin123', '관리자', 'admin@devup.com', CURRENT_TIMESTAMP);
+    (1, 'user1', '$2a$12$L3hwEcWBtlbjNqbBO1Ukv.H2qYEprz6P9uylfT2RujWW9FiAEf9ve', '개발자1', 'user1@devup.com', CURRENT_TIMESTAMP),
+    (2, 'user2', '$2a$12$A5XbxYRC6WAEACzXW1QcpeKbr8NuFhcphfhACaXtRBjpWb2yACMvW', '개발자2', 'user2@devup.com', CURRENT_TIMESTAMP),
+    (3, 'user3', '$2a$12$7jpHtMMoVmHqQgw.mSgBPe8qnVXboRO3k920KCTbzChtHksJkfvo2', '개발자3', 'user3@devup.com', CURRENT_TIMESTAMP),
+    (4, 'admin', '$2a$12$.1kjJ6BpDtwS28rgV/WSo.fnVDKfdUAC3V.qk.gduTNVC9NPWrJ9W', '관리자', 'admin@devup.com', CURRENT_TIMESTAMP);
 
 -- 질문 (questions)
 INSERT INTO questions

--- a/src/main/resources/static/css/auth/signin.css
+++ b/src/main/resources/static/css/auth/signin.css
@@ -1,0 +1,161 @@
+:root {
+    --primary-color: #2C3E50;
+    --secondary-color: #E67E22;
+    --bg-color: #F4F6FB;
+    --text-color: #2E2F3E;
+    --border-color: #DADCE5;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Segoe UI', sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+header, footer {
+    background-color: var(--primary-color);
+    color: #fff;
+    padding: 1rem 2rem;
+}
+
+header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+header nav a {
+    color: #fff;
+    margin-left: 1rem;
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.brand {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+main {
+    flex: 1;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 2rem;
+}
+
+.container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2rem;
+    width: 100%;
+    max-width: 480px;
+}
+
+.slogan {
+    text-align: center;
+    color: var(--primary-color);
+}
+
+.slogan h2 {
+    font-size: 1.3rem;
+    font-weight: bold;
+}
+
+.slogan p {
+    font-size: 0.95rem;
+    margin-top: 0.5rem;
+    color: #555;
+}
+
+
+.signin-box {
+    width: 100%;
+    max-width: 400px;
+    background-color: white;
+    padding: 2rem;
+    border-radius: 8px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+}
+
+.signin-box h2 {
+    text-align: center;
+    margin-bottom: 2rem;
+    color: var(--primary-color);
+}
+
+.form-group {
+    margin-bottom: 1.2rem;
+}
+
+.form-group label {
+    display: block;
+    margin-bottom: 0.5rem;
+    font-weight: 600;
+}
+
+.form-group input {
+    width: 100%;
+    padding: 0.6rem;
+    font-size: 1rem;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+}
+
+.form-group input:focus {
+    outline: none;
+    border-color: var(--primary-color);
+}
+
+.form-actions {
+    text-align: center;
+    margin-top: 1.5rem;
+}
+
+.form-actions button {
+    background-color: var(--secondary-color);
+    color: white;
+    border: none;
+    padding: 0.6rem 2rem;
+    border-radius: 6px;
+    font-size: 1rem;
+    font-weight: bold;
+    cursor: pointer;
+}
+
+.form-actions button:hover {
+    background-color: #cf670b;
+}
+
+.signup-link {
+    margin-top: 1.5rem;
+    text-align: center;
+    font-size: 0.95rem;
+}
+
+.signup-link a {
+    color: var(--primary-color);
+    font-weight: bold;
+    margin-left: 0.3rem;
+    text-decoration: none;
+}
+
+.signup-link a:hover {
+    text-decoration: underline;
+}
+
+footer {
+    text-align: center;
+    font-size: 0.9rem;
+}

--- a/src/main/resources/static/css/auth/signup.css
+++ b/src/main/resources/static/css/auth/signup.css
@@ -1,0 +1,119 @@
+:root {
+    --primary-color: #2C3E50;
+    --secondary-color: #E67E22;
+    --bg-color: #F4F6FB;
+    --text-color: #2E2F3E;
+    --border-color: #DADCE5;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Segoe UI', sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+header,
+footer {
+    background-color: var(--primary-color);
+    color: #fff;
+    padding: 1rem 2rem;
+}
+
+header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+header nav a {
+    color: #fff;
+    margin-left: 1rem;
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.brand {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+main {
+    flex: 1;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 2rem;
+}
+
+.container {
+    width: 100%;
+    max-width: 480px;
+    background: white;
+    padding: 2rem;
+    border-radius: 8px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+}
+
+h2 {
+    text-align: center;
+    color: var(--primary-color);
+    margin-bottom: 2rem;
+}
+
+.form-group {
+    margin-bottom: 1.2rem;
+}
+
+.form-group label {
+    display: block;
+    margin-bottom: 0.5rem;
+    font-weight: 600;
+}
+
+.form-group input {
+    width: 100%;
+    padding: 0.6rem;
+    font-size: 1rem;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+}
+
+.form-group input:focus {
+    outline: none;
+    border-color: var(--primary-color);
+}
+
+.form-actions {
+    text-align: center;
+    margin-top: 1.5rem;
+}
+
+.form-actions button {
+    background-color: var(--secondary-color);
+    color: white;
+    border: none;
+    padding: 0.6rem 2rem;
+    border-radius: 6px;
+    font-size: 1rem;
+    font-weight: bold;
+    cursor: pointer;
+}
+
+.form-actions button:hover {
+    background-color: #cf670b;
+}
+
+footer {
+    text-align: center;
+    font-size: 0.9rem;
+}

--- a/src/main/resources/static/js/auth/signin.js
+++ b/src/main/resources/static/js/auth/signin.js
@@ -1,0 +1,4 @@
+function signin() {
+    // TODO: 로그인 아이디 및 비밀번호 입력 확인
+    // TODO: 로그인 정보 전송
+}

--- a/src/main/resources/static/js/auth/signin.js
+++ b/src/main/resources/static/js/auth/signin.js
@@ -1,4 +1,37 @@
-function signin() {
-    // TODO: 로그인 아이디 및 비밀번호 입력 확인
-    // TODO: 로그인 정보 전송
+const form = document.getElementById("login-form");
+form.addEventListener('submit', handleLoginSubmit);
+
+async function handleLoginSubmit(event) {
+    event.preventDefault();
+
+    const loginId = form.loginId.value;
+    const password = form.password.value;
+
+    try {
+        const url = '/api/auth/signin';
+        const requestInit = {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify({
+                loginId,
+                password
+            })
+        };
+
+        const response = await fetch(url, requestInit);
+        const data = await response.json();
+        console.log(data);
+
+        if (!response.ok) {
+            throw new Error(data.message);
+        }
+
+        // 토큰 저장, 페이지 이동 등 후속 처리
+        localStorage.setItem("token", data.token);
+        window.location.href = data.redirectUrl;
+    } catch (err) {
+        alert(err);
+    }
 }

--- a/src/main/resources/static/js/auth/signup.js
+++ b/src/main/resources/static/js/auth/signup.js
@@ -1,0 +1,85 @@
+function validateSignup() {
+    if (!validateLoginId()) return false;
+    if (!validatePassword()) return false;
+    if (!validateNickname()) return false;
+    if (!validateEmail()) return false;
+    return true;
+}
+
+function validateLoginId() {
+    const loginIdInput = document.getElementById('login_id');
+    const raw = loginIdInput.value;
+    const trimmed = raw.trim();
+
+    if (!trimmed) {
+        alert("아이디를 입력해주세요.");
+        return false;
+    }
+
+    if (raw.length !== trimmed.length) {
+        alert("아이디의 앞뒤에 공백을 포함할 수 없습니다.");
+        return false;
+    }
+
+    return true;
+}
+
+function validatePassword() {
+    const password = document.getElementById('password').value;
+    const passwordConfirm = document.getElementById('password_confirm').value;
+
+    if (!password) {
+        alert("비밀번호를 입력해주세요.");
+        return false;
+    }
+
+    if (!isStrongPassword(password)) {
+        alert("비밀번호는 8자 이상, 영대소문자/숫자/특수문자를 각각 1개 이상 포함해야 합니다.");
+        return false;
+    }
+
+    if (password !== passwordConfirm) {
+        alert("비밀번호와 비밀번호 확인이 일치하지 않습니다.");
+        return false;
+    }
+
+    return true;
+}
+
+function validateNickname() {
+    const nickname = document.getElementById('nickname').value.trim();
+
+    if (!nickname) {
+        alert("닉네임을 입력해주세요.");
+        return false;
+    }
+
+    return true;
+}
+
+function validateEmail() {
+    const email = document.getElementById('email').value.trim();
+    const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+    if (!email) {
+        alert("이메일을 입력해주세요.");
+        return false;
+    }
+
+    if (!emailPattern.test(email)) {
+        alert("올바른 이메일 형식이 아닙니다.");
+        return false;
+    }
+
+    return true;
+}
+
+function isStrongPassword(pw) {
+    return (
+        pw.length >= 8 &&
+        /[A-Z]/.test(pw) &&
+        /[a-z]/.test(pw) &&
+        /\d/.test(pw) &&
+        /[!@#$%^&*(),.?":{}|<>]/.test(pw)
+    );
+}

--- a/src/main/resources/templates/auth/signin.html
+++ b/src/main/resources/templates/auth/signin.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="ko">
+
+<head>
+    <meta charset="UTF-8">
+    <title>로그인 - DevUp</title>
+    <link rel="stylesheet" href="/static/css/signin.css">
+</head>
+
+<body>
+
+<header>
+    <div class="brand">
+        <img src="/static/images/devup_logo.png" alt="DevUp 로고" height="32"/>
+        <strong>DevUp</strong>
+    </div>
+    <nav>
+        <a href="/">홈</a>
+        <a id="question-list" href="#">문제풀이</a>
+        <a id="mypage" href="#">마이페이지</a>
+        <a id="sign-in" href="#">로그인</a>
+    </nav>
+</header>
+<main>
+    <div class="container">
+        <div class="slogan">
+            <h2>🚀 처음이 막막할 땐, DevUp에서 한 문제부터.</h2>
+        </div>
+        <div class="signin-box">
+            <h2>로그인</h2>
+            <form action="#" method="post" onsubmit="return signin();">
+                <div class="form-group">
+                    <label for="login_id">아이디</label>
+                    <input type="text" id="login_id" name="loginId" placeholder="아이디 입력" required>
+                </div>
+                <div class="form-group">
+                    <label for="password">비밀번호</label>
+                    <input type="password" id="password" name="password" placeholder="비밀번호 입력" required>
+                </div>
+                <div class="form-actions">
+                    <button type="submit">로그인</button>
+                </div>
+                <div class="signup-link">
+                    <span>아직 회원이 아니신가요?</span>
+                    <a href="#">회원가입</a>
+                </div>
+            </form>
+        </div>
+    </div>
+</main>
+<footer>
+    &copy; 2025 DevUp |
+    <a
+            href="https://github.com/ckdgus1010/devup"
+            target="_blank"
+            rel="noopener noreferrer"
+            style="color: #ccc; text-decoration: none"
+    >
+        GitHub
+    </a> |
+    이메일: ckdgus3735@gmail.com
+</footer>
+<script id="main-script" src="/static/js/auth/signin.js"/>
+</body>
+</html>

--- a/src/main/resources/templates/auth/signin.html
+++ b/src/main/resources/templates/auth/signin.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <title>로그인 - DevUp</title>
-    <link rel="stylesheet" href="/static/css/signin.css">
+    <link rel="stylesheet" href="/static/css/auth/signin.css">
 </head>
 
 <body>
@@ -28,7 +28,7 @@
         </div>
         <div class="signin-box">
             <h2>로그인</h2>
-            <form action="#" method="post" onsubmit="return signin();">
+            <form id="login-form" action="#" method="post">
                 <div class="form-group">
                     <label for="login_id">아이디</label>
                     <input type="text" id="login_id" name="loginId" placeholder="아이디 입력" required>
@@ -60,6 +60,6 @@
     </a> |
     이메일: ckdgus3735@gmail.com
 </footer>
-<script id="main-script" src="/static/js/auth/signin.js"/>
+<script id="main-script" src="/static/js/auth/signin.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/auth/signin.th.xml
+++ b/src/main/resources/templates/auth/signin.th.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<thlogic xmlns:th="http://www.thymeleaf.org">
+    <attr sel="head">
+        <attr sel="link" th:href="@{/css/auth/signin.css}"/>
+    </attr>
+    <attr sel="body">
+        <attr sel="header">
+            <attr sel=".brand">
+                <attr sel="img" th:src="@{/images/devup_logo.png}"/>
+            </attr>
+            <attr sel="nav">
+                <attr sel="#question-list" th:href="@{/questions?pageNumber=0}"/>
+                <attr sel="#mypage" th:href="@{/mypage}"/>
+                <attr sel="#sign-in" th:href="@{/auth/signin}"/>
+            </attr>
+        </attr>
+        <attr sel="main">
+            <attr sel=".signin-box">
+                <attr sel="form" th:action="@{/api/auth/signin}">
+                    <attr sel="div.signup-link">
+                        <attr sel="a" th:href="@{/auth/signup}"/>
+                    </attr>
+                </attr>
+            </attr>
+        </attr>
+        <attr sel="#main-script" th:src="@{/js/auth/signin.js}"/>
+    </attr>
+</thlogic>

--- a/src/main/resources/templates/auth/signin.th.xml
+++ b/src/main/resources/templates/auth/signin.th.xml
@@ -16,7 +16,7 @@
         </attr>
         <attr sel="main">
             <attr sel=".signin-box">
-                <attr sel="form" th:action="@{/api/auth/signin}">
+                <attr sel="form">
                     <attr sel="div.signup-link">
                         <attr sel="a" th:href="@{/auth/signup}"/>
                     </attr>

--- a/src/main/resources/templates/auth/signup.html
+++ b/src/main/resources/templates/auth/signup.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>회원가입 - DevUp</title>
+    <link rel="stylesheet" href="/static/css/auth/signup.css"/>
+</head>
+<body>
+<header>
+    <div class="brand">
+        <img src="/static/images/devup_logo.png" alt="DevUp 로고" height="32"/>
+        <strong>DevUp</strong>
+    </div>
+    <nav>
+        <a id="question-list" href="#">문제풀이</a>
+        <a id="mypage" href="#">마이페이지</a>
+        <a id="sign-in" href="#">로그인</a>
+    </nav>
+</header>
+
+<main>
+    <div class="container">
+        <h2>회원가입</h2>
+        <form action="#" method="post" onsubmit="return validateSignup();">
+            <div class="form-group">
+                <label for="login_id">아이디</label>
+                <input type="text" id="login_id" name="loginId" placeholder="아이디 입력" required/>
+            </div>
+
+            <div class="form-group">
+                <label for="password">비밀번호</label>
+                <input type="password" id="password" name="password" placeholder="비밀번호 입력" required/>
+            </div>
+
+            <div class="form-group">
+                <label for="password">비밀번호 확인</label>
+                <input type="password" id="password_confirm" name="password_confirm" placeholder="비밀번호 입력" required/>
+            </div>
+
+            <div class="form-group">
+                <label for="nickname">닉네임</label>
+                <input type="text" id="nickname" name="nickname" placeholder="닉네임 입력" required/>
+            </div>
+
+            <div class="form-group">
+                <label for="email">이메일</label>
+                <input type="email" id="email" name="email" placeholder="이메일 입력" required/>
+            </div>
+
+            <div class="form-actions">
+                <button type="submit">가입하기</button>
+            </div>
+        </form>
+    </div>
+</main>
+<footer>
+    &copy; 2025 DevUp |
+    <a
+            href="https://github.com/ckdgus1010/devup"
+            target="_blank"
+            rel="noopener noreferrer"
+            style="color: #ccc; text-decoration: none"
+    >
+        GitHub
+    </a> |
+    이메일: ckdgus3735@gmail.com
+</footer>
+<script id="main-script" src="/static/js/auth/signup.js"/>
+</body>
+</html>

--- a/src/main/resources/templates/auth/signup.th.xml
+++ b/src/main/resources/templates/auth/signup.th.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<thlogic xmlns:th="http://www.thymeleaf.org">
+    <attr sel="head">
+        <attr sel="link" th:href="@{/css/auth/signup.css}"/>
+    </attr>
+    <attr sel="body">
+        <attr sel="header">
+            <attr sel=".brand">
+                <attr sel="img" th:src="@{/images/devup_logo.png}"/>
+            </attr>
+            <attr sel="nav">
+                <attr sel="#question-list" th:href="@{/questions?pageNumber=0}"/>
+                <attr sel="#mypage" th:href="@{/mypage}"/>
+                <attr sel="#sign-in" th:href="@{/sign-in}"/>
+            </attr>
+        </attr>
+        <attr sel="main">
+            <attr sel=".container">
+                <attr sel="form" th:action="@{/signup}"/>
+            </attr>
+        </attr>
+        <attr sel="#main-script" th:src="@{/js/auth/signup.js}"/>
+    </attr>
+</thlogic>


### PR DESCRIPTION
## 작업 내용
- 로그인 화면 구현
- 페이지 호출 및 로그인을 위한 API 제작
- API는 예외 경로로 등록
- 공통 예외 처리 클래스(GlobalExceptionHandler) 추가
- data.sql에 평문으로 저장된 사용자 비밀번호를 Bcrypt Hash Generator를 사용해 암호화

## 참고 사항
- dev profile에서만 CSRF 비활성화 설정하도록 설정
- application.yml에 security.csrf-enabled로 CSRF 활성화 여부 설정
- 따로 설정하지 않으면 활성화 되도록 설정