### PR TITLE
fix: 로그인 성공 시 발급받는 JWT 토큰을 쿠키 저장 방식으로 변경

### DIFF
--- a/src/main/java/com/upstage/devup/auth/config/SecurityConfig.java
+++ b/src/main/java/com/upstage/devup/auth/config/SecurityConfig.java
@@ -49,8 +49,10 @@ public class SecurityConfig {
                         .requestMatchers(PUBLIC_APIS).permitAll()
                         .anyRequest().authenticated()
                 )
-                .formLogin(Customizer.withDefaults())
-                .logout(Customizer.withDefaults());
+                .formLogin(form -> form
+                        .loginPage("/auth/signin")
+                        .permitAll()
+                ).logout(Customizer.withDefaults());
 
         return http.build();
     }

--- a/src/main/java/com/upstage/devup/auth/domain/dto/SignInResponseDto.java
+++ b/src/main/java/com/upstage/devup/auth/domain/dto/SignInResponseDto.java
@@ -5,16 +5,19 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@Builder
-@AllArgsConstructor
 public class SignInResponseDto {
 
-    private String token;
+    private final Long userId;
+    private final String loginId;
+    private final String nickname;
 
-    private Long userId;
-    private String loginId;
-    private String nickname;
+    private final String redirectUrl;
 
-    private String redirectUrl;
+    public SignInResponseDto(SignInResult result) {
+        this.userId = result.getUserId();
+        this.loginId = result.getLoginId();
+        this.nickname = result.getNickname();
 
+        this.redirectUrl = result.getRedirectUrl();
+    }
 }

--- a/src/main/java/com/upstage/devup/auth/domain/dto/SignInResult.java
+++ b/src/main/java/com/upstage/devup/auth/domain/dto/SignInResult.java
@@ -1,0 +1,19 @@
+package com.upstage.devup.auth.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SignInResult {
+
+    private String token;
+
+    private Long userId;
+    private String loginId;
+    private String nickname;
+
+    private String redirectUrl;
+}

--- a/src/main/java/com/upstage/devup/auth/service/UserService.java
+++ b/src/main/java/com/upstage/devup/auth/service/UserService.java
@@ -1,10 +1,7 @@
 package com.upstage.devup.auth.service;
 
 import com.upstage.devup.auth.config.jwt.JwtTokenProvider;
-import com.upstage.devup.auth.domain.dto.SignInRequestDto;
-import com.upstage.devup.auth.domain.dto.SignInResponseDto;
-import com.upstage.devup.auth.domain.dto.SignUpRequestDto;
-import com.upstage.devup.auth.domain.dto.SignUpResponseDto;
+import com.upstage.devup.auth.domain.dto.*;
 import com.upstage.devup.auth.domain.entity.User;
 import com.upstage.devup.auth.domain.mapper.UserMapper;
 import com.upstage.devup.auth.exception.InvalidLoginException;
@@ -34,7 +31,7 @@ public class UserService {
      * @throws IllegalArgumentException 요청 데이터가 null일 때 발생
      * @throws InvalidLoginException 아이디 또는 비밀번호가 일치하지 않는 경우 발생
      */
-    public SignInResponseDto signIn(SignInRequestDto request) {
+    public SignInResult signIn(SignInRequestDto request) {
         if (request == null) {
             throw new IllegalArgumentException("유효하지 않는 요청입니다.");
         }
@@ -53,12 +50,12 @@ public class UserService {
         // JWT 발급
         String token = jwtTokenProvider.generateToken(user.getId());
 
-        return SignInResponseDto.builder()
+        return SignInResult.builder()
                 .token(token)
                 .userId(user.getId())
                 .loginId(user.getLoginId())
                 .nickname(user.getNickname())
-                .redirectUrl("/")
+                .redirectUrl("/mypage")
                 .build();
     }
 


### PR DESCRIPTION
## 작업 내용
- 로그인 성공 시 발급받는 JWT 토큰을 쿠키에 저장하도록 수정
- 기존에는 local storage에 저장하는 방식이었음
- 개발 속도를 높이기 위해 변경
- 인증이 필요할 때 나타나는 로그인 화면을 기본 화면에서 커스텀 로그인 화면으로 변경