### PR TITLE
feat: 오답노트 화면 구현

### DIFF
--- a/src/main/java/com/upstage/devup/user/statistics/controller/UserStatController.java
+++ b/src/main/java/com/upstage/devup/user/statistics/controller/UserStatController.java
@@ -2,7 +2,9 @@ package com.upstage.devup.user.statistics.controller;
 
 import com.upstage.devup.auth.config.AuthenticatedUser;
 import com.upstage.devup.user.statistics.domain.dto.UserSolvedQuestionDto;
+import com.upstage.devup.user.statistics.domain.dto.WrongNoteSummaryDto;
 import com.upstage.devup.user.statistics.service.UserAnswerStatService;
+import com.upstage.devup.user.statistics.service.UserWrongAnswerReadService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserStatController {
 
     private final UserAnswerStatService userAnswerStatService;
+    private final UserWrongAnswerReadService userWrongAnswerReadService;
 
     @GetMapping("/history")
     public ResponseEntity<?> getSolvedQuestions(
@@ -28,5 +31,16 @@ public class UserStatController {
                 = userAnswerStatService.getUserSolvedQuestions(user.getUserId(), pageNumber);
 
         return ResponseEntity.ok(solvedQuestions);
+    }
+
+    @GetMapping("/wrong")
+    public ResponseEntity<?> getWrongNotes(
+            @AuthenticationPrincipal AuthenticatedUser user,
+            @RequestParam Integer pageNumber) {
+
+        Page<WrongNoteSummaryDto> summaries
+                = userWrongAnswerReadService.getWrongNoteSummaries(user.getUserId(), pageNumber);
+
+        return ResponseEntity.ok(summaries);
     }
 }

--- a/src/main/resources/static/css/user/mypage/mypage.css
+++ b/src/main/resources/static/css/user/mypage/mypage.css
@@ -166,6 +166,20 @@ tr:hover {
     cursor: pointer;
 }
 
+.pagination button.active {
+    background-color: var(--secondary-color);
+    color: white;
+    border-color: var(--secondary-color);
+}
+
+.pagination button:disabled {
+    cursor: default;
+}
+
+.pagination button.active:hover {
+    background-color: var(--secondary-color);
+}
+
 .form-group {
     margin-bottom: 1rem;
 }

--- a/src/main/resources/templates/user/mypage/mypage.html
+++ b/src/main/resources/templates/user/mypage/mypage.html
@@ -76,10 +76,10 @@
         </tr>
         </tbody>
     </table>
-    <div class="pagination" id="pagination">
-        <button>1</button>
-        <button>2</button>
-        <button>3</button>
+    <div class="pagination" id="history-pagination">
+        <a>1</a>
+        <a>2</a>
+        <a>3</a>
     </div>
 </template>
 <template class="tab-content" id="wrong">
@@ -93,7 +93,7 @@
             <th>날짜</th>
         </tr>
         </thead>
-        <tbody>
+        <tbody id="wrong-body">
         <tr>
             <td>2</td>
             <td>SQL JOIN 종류</td>
@@ -103,10 +103,10 @@
         </tr>
         </tbody>
     </table>
-    <div class="pagination">
-        <button>1</button>
-        <button>2</button>
-        <button>3</button>
+    <div class="pagination" id="wrong-pagination">
+        <a>1</a>
+        <a>2</a>
+        <a>3</a>
     </div>
 </template>
 <template class="tab-content" id="profile">

--- a/src/test/java/com/upstage/devup/user/statistics/controller/UserStatControllerTest.java
+++ b/src/test/java/com/upstage/devup/user/statistics/controller/UserStatControllerTest.java
@@ -4,7 +4,10 @@ import com.upstage.devup.auth.config.AuthenticatedUser;
 import com.upstage.devup.auth.config.SecurityConfig;
 import com.upstage.devup.auth.config.jwt.JwtTokenProvider;
 import com.upstage.devup.user.statistics.domain.dto.UserSolvedQuestionDto;
+import com.upstage.devup.user.statistics.domain.dto.WrongNoteSummaryDto;
 import com.upstage.devup.user.statistics.service.UserAnswerStatService;
+import com.upstage.devup.user.statistics.service.UserWrongAnswerReadService;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -14,8 +17,10 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -39,9 +44,13 @@ class UserStatControllerTest {
     private UserAnswerStatService userAnswerStatService;
 
     @MockitoBean
+    private UserWrongAnswerReadService userWrongAnswerReadService;
+
+    @MockitoBean
     private JwtTokenProvider jwtTokenProvider;
 
     @Test
+    @DisplayName("사용자 문제 풀이 이력 조회 성공")
     public void shouldGetSolvedQuestions() throws Exception {
         // given
         Long userId = 1L;
@@ -70,9 +79,7 @@ class UserStatControllerTest {
         // when & then
         mockMvc.perform(get("/api/stat/history")
                         .param("pageNumber", String.valueOf(pageNumber))
-                        .with(authentication(new UsernamePasswordAuthenticationToken(
-                                new AuthenticatedUser(userId), null, null
-                        ))))
+                        .with(getAuthentication(userId)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content").isArray())
                 .andExpect(jsonPath("$.content[0].id").value(dto.getId()))
@@ -84,5 +91,50 @@ class UserStatControllerTest {
                 .andExpect(jsonPath("$.content[0].lastSolvedAt").value(dto.getLastSolvedAt()))
                 .andExpect(jsonPath("$.content[0].correct").value(String.valueOf(dto.isCorrect())))
                 .andExpect(jsonPath("$.totalElements").value(String.valueOf(items.size())));
+    }
+
+    @Test
+    @DisplayName("오답 노트 목록 조회 성공")
+    public void shouldGetWrongNote() throws Exception {
+        // given
+        Long userId = 1L;
+
+        Integer pageNumber = 0;
+        int pageSize = 10;
+
+        WrongNoteSummaryDto dto = WrongNoteSummaryDto.builder()
+                .userId(userId)
+                .questionId(1L)
+                .title("임시 제목")
+                .category("임시 카테고리")
+                .level("임시 난이도")
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        List<WrongNoteSummaryDto> items = List.of(dto);
+        Pageable pageable = PageRequest.of(pageNumber, pageSize);
+        Page<WrongNoteSummaryDto> mockPage = new PageImpl<>(items, pageable, items.size());
+
+        when(userWrongAnswerReadService.getWrongNoteSummaries(eq(userId), eq(pageNumber)))
+                .thenReturn(mockPage);
+
+        // when & then
+        mockMvc.perform(get("/api/stat/wrong")
+                        .param("pageNumber", String.valueOf(pageNumber))
+                        .with(getAuthentication(userId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.content[0].userId").value(String.valueOf(userId)))
+                .andExpect(jsonPath("$.content[0].questionId").value(String.valueOf(dto.getQuestionId())))
+                .andExpect(jsonPath("$.content[0].title").value(String.valueOf(dto.getTitle())))
+                .andExpect(jsonPath("$.content[0].category").value(String.valueOf(dto.getCategory())))
+                .andExpect(jsonPath("$.content[0].level").value(String.valueOf(dto.getLevel())))
+                .andExpect(jsonPath("$.content[0].createdAt").value(String.valueOf(dto.getCreatedAt())));
+    }
+
+    private RequestPostProcessor getAuthentication(Long userId) {
+        AuthenticatedUser user = new AuthenticatedUser(userId);
+        Authentication auth = new UsernamePasswordAuthenticationToken(user, null, null);
+        return authentication(auth);
     }
 }


### PR DESCRIPTION
## 작업 내용
- 오답 노트 목록 호출용 API 제작
- API 테스트 코드 작성 및 통과 확인
- 오답노트 화면 구현
- 페이징 처리
- 현재 페이지 번호 강조 및 클릭 안되도록 CSS 수정

## 참고 사항
- 풀이 이력 목록 및 페이징 처리 메서드를 재사용 가능하도록 리펙터링
- 리펙터링 한 JavaScript 메서드로 오답노트 목록 및 페이징 처리