### PR TITLE
feat: 마이페이지 사용자 정보 탭 UI 수정 및 기능 구현

### DIFF
--- a/src/main/java/com/upstage/devup/auth/domain/entity/User.java
+++ b/src/main/java/com/upstage/devup/auth/domain/entity/User.java
@@ -36,4 +36,12 @@ public class User {
     private LocalDateTime createdAt;
 
     private LocalDateTime modifiedAt;
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updateEmail(String email) {
+        this.email = email;
+    }
 }

--- a/src/main/java/com/upstage/devup/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/upstage/devup/global/handler/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.upstage.devup.global.handler;
 
 import com.upstage.devup.auth.exception.InvalidLoginException;
 import com.upstage.devup.global.domain.dto.ErrorResponse;
+import com.upstage.devup.global.exception.EntityNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -15,5 +16,12 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.UNAUTHORIZED)
                 .body(new ErrorResponse("INVALID_LOGIN", e.getMessage()));
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleEntityNotFound(EntityNotFoundException e) {
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(new ErrorResponse("NOT_FOUND", e.getMessage()));
     }
 }

--- a/src/main/java/com/upstage/devup/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/upstage/devup/global/handler/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.upstage.devup.global.handler;
 import com.upstage.devup.auth.exception.InvalidLoginException;
 import com.upstage.devup.global.domain.dto.ErrorResponse;
 import com.upstage.devup.global.exception.EntityNotFoundException;
+import com.upstage.devup.global.exception.ValueAlreadyInUseException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -23,5 +24,12 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.NOT_FOUND)
                 .body(new ErrorResponse("NOT_FOUND", e.getMessage()));
+    }
+
+    @ExceptionHandler(ValueAlreadyInUseException.class)
+    public ResponseEntity<ErrorResponse> handleValueAlreadInUse(ValueAlreadyInUseException e) {
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(new ErrorResponse("VALUE_ALREADY_IN_USE", e.getMessage()));
     }
 }

--- a/src/main/java/com/upstage/devup/user/account/controller/UserAccountController.java
+++ b/src/main/java/com/upstage/devup/user/account/controller/UserAccountController.java
@@ -2,13 +2,12 @@ package com.upstage.devup.user.account.controller;
 
 import com.upstage.devup.auth.config.AuthenticatedUser;
 import com.upstage.devup.user.account.dto.UserAccountDto;
+import com.upstage.devup.user.account.dto.UserAccountUpdateDto;
 import com.upstage.devup.user.account.service.UserAccountService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/user/account")
@@ -20,6 +19,16 @@ public class UserAccountController {
     @GetMapping
     public ResponseEntity<?> getUserAccount(@AuthenticationPrincipal AuthenticatedUser user) {
         UserAccountDto result = userAccountService.getUserAccount(user.getUserId());
+        return ResponseEntity.ok(result);
+    }
+
+    @PatchMapping
+    public ResponseEntity<?> updateUserAccount(
+            @AuthenticationPrincipal AuthenticatedUser user,
+            @RequestBody UserAccountUpdateDto userAccountUpdateDto) {
+
+        System.out.println("UserAccountController.updateUserAccount");
+        UserAccountDto result = userAccountService.updateUserAccount(user.getUserId(), userAccountUpdateDto);
         return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/com/upstage/devup/user/account/controller/UserAccountController.java
+++ b/src/main/java/com/upstage/devup/user/account/controller/UserAccountController.java
@@ -1,0 +1,25 @@
+package com.upstage.devup.user.account.controller;
+
+import com.upstage.devup.auth.config.AuthenticatedUser;
+import com.upstage.devup.user.account.dto.UserAccountDto;
+import com.upstage.devup.user.account.service.UserAccountService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/user/account")
+@RequiredArgsConstructor
+public class UserAccountController {
+
+    private final UserAccountService userAccountService;
+
+    @GetMapping
+    public ResponseEntity<?> getUserAccount(@AuthenticationPrincipal AuthenticatedUser user) {
+        UserAccountDto result = userAccountService.getUserAccount(user.getUserId());
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/com/upstage/devup/user/account/dto/UserAccountDto.java
+++ b/src/main/java/com/upstage/devup/user/account/dto/UserAccountDto.java
@@ -1,0 +1,27 @@
+package com.upstage.devup.user.account.dto;
+
+import com.upstage.devup.auth.domain.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UserAccountDto {
+
+    private Long userId;
+    private String loginId;
+    private String nickname;
+    private String email;
+
+    public static UserAccountDto of(User entity) {
+        return UserAccountDto.builder()
+                .userId(entity.getId())
+                .loginId(entity.getLoginId())
+                .nickname(entity.getNickname())
+                .email(entity.getEmail())
+                .build();
+    }
+
+}

--- a/src/main/java/com/upstage/devup/user/account/dto/UserAccountUpdateDto.java
+++ b/src/main/java/com/upstage/devup/user/account/dto/UserAccountUpdateDto.java
@@ -1,0 +1,16 @@
+package com.upstage.devup.user.account.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UserAccountUpdateDto {
+
+    private String type;
+    private String nickname;
+    private String email;
+
+}

--- a/src/main/java/com/upstage/devup/user/account/service/UserAccountService.java
+++ b/src/main/java/com/upstage/devup/user/account/service/UserAccountService.java
@@ -1,0 +1,35 @@
+package com.upstage.devup.user.account.service;
+
+import com.upstage.devup.auth.domain.entity.User;
+import com.upstage.devup.auth.respository.UserRepository;
+import com.upstage.devup.global.exception.EntityNotFoundException;
+import com.upstage.devup.user.account.dto.UserAccountDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class UserAccountService {
+
+    private final UserRepository userRepository;
+
+    /**
+     * 사용자 정보 불러오기
+     *
+     * @param userId 사용자 ID
+     * @return 조회된 사용자 정보
+     * @throws EntityNotFoundException 회원 정보를 찾을 수 없을 때 발생
+     */
+    public UserAccountDto getUserAccount(Long userId) {
+        if (userId == null) {
+            throw new EntityNotFoundException("회원 정보를 찾을 수 없습니다.");
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("회원 정보를 찾을 수 없습니다."));
+
+        return UserAccountDto.of(user);
+    }
+}

--- a/src/main/java/com/upstage/devup/user/account/service/UserAccountService.java
+++ b/src/main/java/com/upstage/devup/user/account/service/UserAccountService.java
@@ -3,7 +3,9 @@ package com.upstage.devup.user.account.service;
 import com.upstage.devup.auth.domain.entity.User;
 import com.upstage.devup.auth.respository.UserRepository;
 import com.upstage.devup.global.exception.EntityNotFoundException;
+import com.upstage.devup.global.exception.ValueAlreadyInUseException;
 import com.upstage.devup.user.account.dto.UserAccountDto;
+import com.upstage.devup.user.account.dto.UserAccountUpdateDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -31,5 +33,62 @@ public class UserAccountService {
                 .orElseThrow(() -> new EntityNotFoundException("회원 정보를 찾을 수 없습니다."));
 
         return UserAccountDto.of(user);
+    }
+
+    public UserAccountDto updateUserAccount(Long userId, UserAccountUpdateDto request) {
+        if (userId == null) {
+            throw new EntityNotFoundException("회원 정보를 찾을 수 없습니다.");
+        }
+
+        if (request == null) {
+            throw new IllegalArgumentException("유효한 데이터가 아닙니다.");
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("회원 정보를 찾을 수 없습니다."));
+
+        switch (request.getType()) {
+            case "nickname":
+                updateNickname(user, request.getNickname());
+                break;
+            case "email":
+                updateEmail(user, request.getEmail());
+                break;
+        }
+
+        User saved = userRepository.save(user);
+        return UserAccountDto.of(saved);
+    }
+
+    private void updateNickname(User user, String newNickname) {
+        if (newNickname == null || newNickname.isBlank()) {
+            throw new IllegalArgumentException("유효하지 않은 닉네임입니다.");
+        }
+
+        if (user.getNickname().equals(newNickname)) {
+            throw new ValueAlreadyInUseException("이미 사용중인 닉네임입니다.");
+        }
+
+        if (userRepository.existsByNickname(newNickname)) {
+            throw new ValueAlreadyInUseException("이미 사용중인 닉네임입니다.");
+        }
+
+        user.updateNickname(newNickname);
+    }
+
+    private void updateEmail(User user, String newEmail) {
+        if (newEmail == null || newEmail.isBlank()) {
+            throw new IllegalArgumentException("유효하지 않은 이메일입니다.");
+        }
+
+        if (user.getEmail().equals(newEmail)) {
+            throw new ValueAlreadyInUseException("이미 사용중인 이메일입니다.");
+        }
+
+        if (userRepository.existsByEmail(newEmail)) {
+            throw new ValueAlreadyInUseException("이미 사용중인 이메일입니다.");
+        }
+
+        user.updateEmail(newEmail);
     }
 }

--- a/src/main/resources/static/js/user/mypage/mypage-profile.js
+++ b/src/main/resources/static/js/user/mypage/mypage-profile.js
@@ -1,0 +1,99 @@
+export async function showProfile() {
+    const loginIdEl = document.getElementById("login_id");
+    const nicknameEl = document.getElementById("nickname");
+    const emailEl = document.getElementById("email");
+
+    loginIdEl.value = '';
+    nicknameEl.value = '';
+    emailEl.value = '';
+
+    try {
+        const url = '/api/user/account';
+        const response = await fetch(url, {method: "GET"});
+        const data = await response.json();
+
+        loginIdEl.value = data.loginId;
+        nicknameEl.value = data.nickname;
+        emailEl.value = data.email;
+
+        setHandlersToProfileButtons();
+    } catch (err) {
+        alert(err);
+    }
+}
+
+export function setHandlersToProfileButtons() {
+    const nicknameBtn = document.getElementById("nickname-btn");
+    const emailBtn = document.getElementById("email-btn");
+
+    nicknameBtn.addEventListener('click', updateNickname);
+    emailBtn.addEventListener('click', updateEmail);
+}
+
+// 닉네임 수정
+async function updateNickname() {
+    const nicknameInput = document.getElementById("nickname");
+    const newNickname = nicknameInput.value;
+
+    if (newNickname == null || newNickname.trim().length === 0) {
+        alert("닉네임을 확인해주세요.");
+        return;
+    }
+
+    try {
+        const response = await fetch('/api/user/account', {
+            method: 'PATCH',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                'type': 'nickname',
+                'nickname': newNickname
+            })
+        });
+        const data = await response.json();
+
+        if (!response.ok) {
+            throw new Error(data.message);
+        }
+
+        alert("닉네임을 수정했습니다.")
+        nicknameInput.value = data.nickname;
+    } catch (err) {
+        alert(err);
+    }
+}
+
+// 이메일 수정
+async function updateEmail() {
+    const emailInput = document.getElementById("email");
+    const newEmail = emailInput.value;
+
+    if (newEmail == null || newEmail.trim().length === 0) {
+        alert("이메일을 확인해주세요.");
+        return;
+    }
+
+    try {
+        const response = await fetch('/api/user/account', {
+            method: 'PATCH',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                'type': 'email',
+                'email': newEmail
+            })
+        });
+        const data = await response.json();
+
+        if (!response.ok) {
+            throw new Error(data.message);
+        }
+
+        alert("이메일을 수정했습니다.")
+        emailInput.value = data.email;
+    } catch (err) {
+        alert(err);
+    }
+}

--- a/src/main/resources/static/js/user/mypage/mypage.js
+++ b/src/main/resources/static/js/user/mypage/mypage.js
@@ -55,7 +55,21 @@ async function showTab(tabName) {
 }
 
 async function showProfile() {
-    console.log("회원 정보 보기");
+    const loginIdEl = document.getElementById("login_id");
+    const nicknameEl = document.getElementById("nickname");
+    const emailEl = document.getElementById("email");
+
+    loginIdEl.value = '';
+    nicknameEl.value = '';
+    emailEl.value = '';
+
+    const url = '/api/user/account';
+    const response = await fetch(url, {method: "GET"});
+    const data = await response.json();
+
+    loginIdEl.value = data.loginId;
+    nicknameEl.value = data.nickname;
+    emailEl.value = data.email;
 }
 
 // 오답 노트 목록 보여주기

--- a/src/main/resources/static/js/user/mypage/mypage.js
+++ b/src/main/resources/static/js/user/mypage/mypage.js
@@ -1,3 +1,5 @@
+import {showProfile} from '/js/user/mypage/mypage-profile.js';
+
 const tabContainer = document.getElementById('tab-container');
 const buttons = document.querySelectorAll(".tab-button");
 let currentTabButton = null;
@@ -7,7 +9,7 @@ const tabActionMap = {
     },
     history: () => showUserSolvedQuestions(0),
     wrong: () => showWrongNote(0),
-    profile: () => showProfile()
+    profile: showProfile
 };
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -52,24 +54,6 @@ async function showTab(tabName) {
     if (typeof action === 'function') {
         await action();
     }
-}
-
-async function showProfile() {
-    const loginIdEl = document.getElementById("login_id");
-    const nicknameEl = document.getElementById("nickname");
-    const emailEl = document.getElementById("email");
-
-    loginIdEl.value = '';
-    nicknameEl.value = '';
-    emailEl.value = '';
-
-    const url = '/api/user/account';
-    const response = await fetch(url, {method: "GET"});
-    const data = await response.json();
-
-    loginIdEl.value = data.loginId;
-    nicknameEl.value = data.nickname;
-    emailEl.value = data.email;
 }
 
 // 오답 노트 목록 보여주기

--- a/src/main/resources/templates/user/mypage/mypage.html
+++ b/src/main/resources/templates/user/mypage/mypage.html
@@ -119,7 +119,7 @@
             <label for="nickname">닉네임</label>
             <div class="form-inline">
                 <input type="text" id="nickname" value="devuser"/>
-                <button type="button">수정</button>
+                <button type="button" id="nickname-btn">수정</button>
             </div>
         </div>
 
@@ -127,17 +127,17 @@
             <label for="email">이메일</label>
             <div class="form-inline">
                 <input type="email" id="email" value="devup@example.com"/>
-                <button type="button">수정</button>
+                <button type="button" id="email-btn">수정</button>
             </div>
         </div>
 
-        <div class="form-group">
-            <label for="password">비밀번호</label>
-            <div class="form-inline">
-                <input type="password" id="password" placeholder="새 비밀번호 입력"/>
-                <button type="button">변경</button>
-            </div>
-        </div>
+<!--        <div class="form-group">-->
+<!--            <label for="password">비밀번호</label>-->
+<!--            <div class="form-inline">-->
+<!--                <input type="password" id="password" placeholder="새 비밀번호 입력"/>-->
+<!--                <button type="button" id="password-btn">변경</button>-->
+<!--            </div>-->
+<!--        </div>-->
 
     </form>
 </template>
@@ -148,7 +148,7 @@
     이메일: devup@devup.com
 </footer>
 
-<script id="main-script" src="/static/js/user/mypage/mypage.js"></script>
+<script id="main-script" type="module" src="/static/js/user/mypage/mypage.js"></script>
 
 </body>
 </html>

--- a/src/test/java/com/upstage/devup/auth/service/UserAccountServiceTest.java
+++ b/src/test/java/com/upstage/devup/auth/service/UserAccountServiceTest.java
@@ -1,0 +1,66 @@
+package com.upstage.devup.auth.service;
+
+import com.upstage.devup.global.exception.EntityNotFoundException;
+import com.upstage.devup.user.account.dto.UserAccountDto;
+import com.upstage.devup.user.account.service.UserAccountService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+public class UserAccountServiceTest {
+
+    @Autowired
+    private UserAccountService userAccountService;
+
+    @Test
+    @DisplayName("유저 정보 조회 성공")
+    public void shouldReturnUserAccountDto_whenValidRequest() {
+        // given
+        Long userId = 1L;
+
+        // when
+        UserAccountDto result = userAccountService.getUserAccount(userId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getUserId()).isEqualTo(userId);
+    }
+
+    @Test
+    @DisplayName("유저 정보 조회 실패 - 사용자 ID가 null인 경우 EntityNotFoundException 발생")
+    public void shouldThrowEntityNotFoundException_whenUserIdIsNull() {
+        // given
+        Long userId = null;
+        String errorMessage = "회원 정보를 찾을 수 없습니다.";
+
+        // when & then
+        EntityNotFoundException exception = assertThrows(
+                EntityNotFoundException.class,
+                () ->userAccountService.getUserAccount(userId)
+        );
+
+        assertThat(exception.getMessage()).isEqualTo(errorMessage);
+    }
+
+    @Test
+    @DisplayName("유저 정보 조회 실패 - 유효하지 않은 사용자 ID를 사용한 경우 EntityNotFoundException 발생")
+    public void shouldThrowEntityNotFoundException_whenUserIdIsUnavailable() {
+        // given
+        Long userId = 0L;
+        String errorMessage = "회원 정보를 찾을 수 없습니다.";
+
+        // when & then
+        EntityNotFoundException exception = assertThrows(
+                EntityNotFoundException.class,
+                () ->userAccountService.getUserAccount(userId)
+        );
+
+        assertThat(exception.getMessage()).isEqualTo(errorMessage);
+    }
+}

--- a/src/test/java/com/upstage/devup/user/account/controller/UserAccountControllerTest.java
+++ b/src/test/java/com/upstage/devup/user/account/controller/UserAccountControllerTest.java
@@ -1,0 +1,101 @@
+package com.upstage.devup.user.account.controller;
+
+import com.upstage.devup.auth.config.AuthenticatedUser;
+import com.upstage.devup.auth.config.SecurityConfig;
+import com.upstage.devup.auth.config.jwt.JwtTokenProvider;
+import com.upstage.devup.global.exception.EntityNotFoundException;
+import com.upstage.devup.user.account.dto.UserAccountDto;
+import com.upstage.devup.user.account.service.UserAccountService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(UserAccountController.class)
+@Import(SecurityConfig.class)
+class UserAccountControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private UserAccountService userAccountService;
+
+    private static final String urlTemplate = "/api/user/account";
+
+    @Test
+    @DisplayName("사용자 계정 정보 조회 성공")
+    public void shouldReturnUserAccount_whenAuthenticatedRequest() throws Exception {
+        // given
+        Long userId = 1L;
+
+        UserAccountDto mockDto = UserAccountDto.builder()
+                .userId(userId)
+                .loginId("dev123")
+                .nickname("개발자123")
+                .email("dev123@gmail.com")
+                .build();
+
+        when(userAccountService.getUserAccount(eq(userId)))
+                .thenReturn(mockDto);
+
+        // when & then
+        mockMvc.perform(get(urlTemplate)
+                        .with(getAuthentication(userId)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.userId").value(userId.toString()))
+                .andExpect(jsonPath("$.loginId").value(mockDto.getLoginId()))
+                .andExpect(jsonPath("$.nickname").value(mockDto.getNickname()))
+                .andExpect(jsonPath("$.email").value(mockDto.getEmail()));
+    }
+
+    @Test
+    @DisplayName("사용자 계정 정보 조회 실패 - 인증되지 않은 접근인 경우")
+    public void shouldReturnUnauthorized_whenRequestIsNotAuthenticated() throws Exception {
+        mockMvc.perform(get(urlTemplate))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("사용자 계정 정보 조회 실패 - 유효하지 않은 사용자 ID를 사용한 경우")
+    public void shouldThrowNotFound_whenUserIdIsUnavailable() throws Exception {
+        // given
+        Long userId = 0L;
+        final String errorMessage = "회원 정보를 찾을 수 없습니다.";
+
+        when(userAccountService.getUserAccount(eq(userId)))
+                .thenThrow(new EntityNotFoundException(errorMessage));
+
+        // when & then
+        mockMvc.perform(get(urlTemplate)
+                        .with(getAuthentication(userId)))
+                .andExpect(status().isNotFound())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value(errorMessage));
+    }
+
+    private RequestPostProcessor getAuthentication(Long userId) {
+        AuthenticatedUser user = new AuthenticatedUser(userId);
+        Authentication auth = new UsernamePasswordAuthenticationToken(user, null, null);
+
+        return authentication(auth);
+    }
+
+}


### PR DESCRIPTION
## 작업 내용
- 사용자 정보 탭 UI 수정
  - '비밀번호 변경' 칸은 주석 처리(리팩터링 후 추가할 예정)
- [수정] 버튼에 사용자 정보 수정 기능 연결
- 사용자 계정 정보 수정용 API 제작(`PATCH /api/user/account`)

## 참고 사항
- 마이페이지 관련 코드는 `mypage.js`에서 관리
- 여러 기능이 추가되면서 파일이 길어지고 있어 가독성이 떨어짐
- 사용자 정보 탭과 관련된 기능들은 `mypage-profile.js`로 관리
- `mypage.js` 상단에 `mypage-profile.js`를 import하여 연결
- 다른 탭 관련 기능들도 파일을 나눠서 관리할 예정