### PR TITLE
refactor: 홈 UI 수정 및 기능 연결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6:3.1.2.RELEASE'
 
 	// JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/resources/static/css/index.css
+++ b/src/main/resources/static/css/index.css
@@ -104,6 +104,7 @@ main {
     border: none;
     border-radius: 4px;
     font-size: 1rem;
+    text-decoration: none;
     cursor: pointer;
     transition: background-color 0.2s;
 }

--- a/src/main/resources/static/js/header.js
+++ b/src/main/resources/static/js/header.js
@@ -1,0 +1,19 @@
+async function logout() {
+    try {
+        const response = await fetch('/api/auth/logout', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        });
+
+        if (!response.ok) {
+            throw new Error("로그아웃을 할 수 없습니다.");
+        }
+
+        const data = await response.json();
+        window.location.href = data.redirectUrl;
+    } catch (err) {
+        alert(err);
+    }
+}

--- a/src/main/resources/templates/common/header.html
+++ b/src/main/resources/templates/common/header.html
@@ -1,4 +1,4 @@
-<header>
+<header xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
     <div class="brand">
         <img src="/images/devup_logo.png" alt="DevUp 로고" height="32"/>
         <strong>DevUp</strong>
@@ -6,7 +6,9 @@
     <nav>
         <a href="/">홈</a>
         <a href="/questions?pageNumber=0">문제풀이</a>
-        <a href="/mypage">마이페이지</a>
-        <a href="/auth/signin">로그인</a>
+        <a href="/mypage" sec:authorize="isAuthenticated()">마이페이지</a>
+        <a href="/auth/signin" sec:authorize="isAnonymous()">로그인</a>
+        <a href="#" onclick="logout()" sec:authorize="isAuthenticated()">로그아웃</a>
     </nav>
+    <script th:src="@{/js/header.js}"></script>
 </header>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -13,9 +13,10 @@
         <strong>DevUp</strong>
     </div>
     <nav>
-        <a id="question-list" href="#">문제풀이</a>
-        <a id="mypage" href="#">마이페이지</a>
-        <a id="sign-in" href="#">로그인</a>
+        <a href="#">홈</a>
+        <a href="#">문제풀이</a>
+        <a href="#">마이페이지</a>
+        <a href="#">로그인</a>
     </nav>
 </header>
 <main>
@@ -26,7 +27,7 @@
                 DevUp은 개발자 면접을 준비하는 사람들을 위한<br/>
                 실전 문제 풀이 및 오답 관리 플랫폼입니다.
             </p>
-            <button class="start-btn">지금 시작하기</button>
+            <a class="start-btn" id="start-btn" href="#">지금 시작하기</a>
         </div>
         <div class="hero-image">
             <img src="/static/images/undraw_interview_yz52.svg" alt="인터뷰"/>
@@ -35,7 +36,7 @@
 </main>
 <footer id="footer">
     &copy; 2025 DevUp |
-    <a href="#" target="_blank" rel="noopener noreferrer">GitHub</a> |
+    <a href="#">GitHub</a> |
     이메일: devup@devup.com
 </footer>
 </body>

--- a/src/main/resources/templates/index.th.xml
+++ b/src/main/resources/templates/index.th.xml
@@ -6,6 +6,7 @@
     <attr sel="body">
         <attr sel="#header" th:replace="~{common/header :: header}"/>
         <attr sel="main">
+            <attr sel="#start-btn" th:href="@{/auth/signin}"/>
             <attr sel="div.hero-image">
                 <attr sel="img" th:src="@{/images/undraw_interview_yz52.svg}"/>
             </attr>


### PR DESCRIPTION
## 작업 내용
### 홈 UI 수정 및 기능 연결
- 홈 화면의 [지금 시작하기] 버튼 클릭 시 로그인 페이지로 이동하도록 설정
- 로그인 여부에 따라 헤더의 네비게이션 메뉴가 다르게 나오도록 설정

### 로그인 상태 별 메뉴 구성
| 로그인 상태 | 표시되는 메뉴                                              |
|-----------|---------------------------------------|
| 로그인 O    | `홈`, `문제풀이`, `마이페이지`, `로그아웃` |
| 로그인 X     | `홈`, `문제풀이`, `로그인`                          |

### `thymeleaf-extras-springsecurity6` 의존성 추가
- Thymeleaf 템플릿에서 Spring Security 인증 정보를 활용하기 위한 의존성 추가
- `sec:authorize` 등 보안 표현식 사용 가능