### PR TITLE
feat: 사용자 풀이 내역 상세 페이지 구현 및 풀이 이력 조회 로직 수정

### DIFF
--- a/src/main/java/com/upstage/devup/user/answer/controller/UserAnswerSaveController.java
+++ b/src/main/java/com/upstage/devup/user/answer/controller/UserAnswerSaveController.java
@@ -1,0 +1,39 @@
+package com.upstage.devup.user.answer.controller;
+
+import com.upstage.devup.auth.config.AuthenticatedUser;
+import com.upstage.devup.global.exception.UnauthenticatedException;
+import com.upstage.devup.user.answer.dto.UserAnswerDetailDto;
+import com.upstage.devup.user.answer.dto.UserAnswerSaveRequest;
+import com.upstage.devup.user.answer.service.UserAnswerSaveService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/user/answer")
+@RequiredArgsConstructor
+public class UserAnswerSaveController {
+
+    private final UserAnswerSaveService userAnswerSaveService;
+
+    @PostMapping
+    public ResponseEntity<?> saveUserAnswer(
+            @AuthenticationPrincipal AuthenticatedUser user,
+            @RequestBody @Valid UserAnswerSaveRequest request) {
+
+        if (user == null) {
+            throw new UnauthenticatedException("로그인이 필요합니다.");
+        }
+
+        UserAnswerDetailDto result = userAnswerSaveService.saveUserAnswer(user.getUserId(), request);
+
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/com/upstage/devup/user/answer/controller/UserAnswerSaveController.java
+++ b/src/main/java/com/upstage/devup/user/answer/controller/UserAnswerSaveController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
-@RequestMapping("/user/answer")
+@RequestMapping("/api/user/answer")
 @RequiredArgsConstructor
 public class UserAnswerSaveController {
 

--- a/src/main/java/com/upstage/devup/user/answer/dto/UserAnswerDetailDto.java
+++ b/src/main/java/com/upstage/devup/user/answer/dto/UserAnswerDetailDto.java
@@ -1,5 +1,6 @@
 package com.upstage.devup.user.answer.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -25,5 +26,7 @@ public class UserAnswerDetailDto {
     private String answerText;
 
     private Boolean isCorrect;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/upstage/devup/user/answer/dto/UserAnswerSaveRequest.java
+++ b/src/main/java/com/upstage/devup/user/answer/dto/UserAnswerSaveRequest.java
@@ -1,5 +1,7 @@
 package com.upstage.devup.user.answer.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 @Getter
@@ -9,8 +11,13 @@ import lombok.*;
 @AllArgsConstructor
 public class UserAnswerSaveRequest {
 
+    @NotNull(message = "유효한 면접 질문이 아닙니다.")
     private Long questionId;
+
+    @NotBlank(message = "정답을 입력해 주세요.")
     private String answerText;
+
+    @NotNull(message = "정답 여부를 확인해 주세요.")
     private Boolean isCorrect;
 
 }

--- a/src/main/java/com/upstage/devup/user/answer/service/UserAnswerSaveService.java
+++ b/src/main/java/com/upstage/devup/user/answer/service/UserAnswerSaveService.java
@@ -1,15 +1,11 @@
 package com.upstage.devup.user.answer.service;
 
-import com.upstage.devup.global.entity.User;
+import com.upstage.devup.global.entity.*;
 import com.upstage.devup.global.exception.EntityNotFoundException;
 import com.upstage.devup.question.dto.QuestionDetailDto;
-import com.upstage.devup.global.entity.Question;
 import com.upstage.devup.question.service.QuestionService;
 import com.upstage.devup.user.answer.dto.UserAnswerDetailDto;
 import com.upstage.devup.user.answer.dto.UserAnswerSaveRequest;
-import com.upstage.devup.global.entity.UserAnswer;
-import com.upstage.devup.global.entity.UserAnswerStat;
-import com.upstage.devup.global.entity.UserWrongAnswer;
 import com.upstage.devup.user.answer.repository.AnswerUserRepository;
 import com.upstage.devup.user.answer.repository.UserAnswerRepository;
 import com.upstage.devup.user.answer.repository.UserAnswerStatRepository;
@@ -153,23 +149,6 @@ public class UserAnswerSaveService {
 
         userAnswerStat.setLastSolvedAt(context.getNow());
         userAnswerStatRepository.save(userAnswerStat);
-    }
-
-    private UserAnswerDetailDto toUserAnswerDetailDto(UserAnswer userAnswer) {
-        Question question = userAnswer.getQuestion();
-
-        return UserAnswerDetailDto.builder()
-                .userId(userAnswer.getUser().getId())
-                .questionId(question.getId())
-                .title(question.getTitle())
-                .questionText(question.getQuestionText())
-                .category(question.getCategory().getCategory())
-                .level(question.getLevel().getLevel())
-                .userAnswerId(userAnswer.getId())
-                .answerText(userAnswer.getAnswerText())
-                .isCorrect(userAnswer.getIsCorrect())
-                .createdAt(userAnswer.getCreatedAt())
-                .build();
     }
 
     @Getter

--- a/src/main/java/com/upstage/devup/user/history/controller/UserSolvedHistoryController.java
+++ b/src/main/java/com/upstage/devup/user/history/controller/UserSolvedHistoryController.java
@@ -1,0 +1,35 @@
+package com.upstage.devup.user.history.controller;
+
+import com.upstage.devup.auth.config.AuthenticatedUser;
+import com.upstage.devup.user.history.service.UserSolvedHistoryService;
+import com.upstage.devup.user.history.dto.UserSolvedQuestionDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/user/history")
+@RequiredArgsConstructor
+public class UserSolvedHistoryController {
+
+    private final UserSolvedHistoryService userSolvedHistoryService;
+
+
+    @GetMapping
+    public ResponseEntity<?> getSolvedHistories(
+            @AuthenticationPrincipal AuthenticatedUser user,
+            @RequestParam Integer pageNumber) {
+
+        Page<UserSolvedQuestionDto> results
+                = userSolvedHistoryService.getUserSolvedQuestions(user.getUserId(), pageNumber);
+
+        return ResponseEntity.ok(results);
+    }
+}

--- a/src/main/java/com/upstage/devup/user/history/controller/UserSolvedHistoryController.java
+++ b/src/main/java/com/upstage/devup/user/history/controller/UserSolvedHistoryController.java
@@ -15,12 +15,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
-@RequestMapping("/user/history")
+@RequestMapping("/api/user/history")
 @RequiredArgsConstructor
 public class UserSolvedHistoryController {
 
     private final UserSolvedHistoryService userSolvedHistoryService;
-
 
     @GetMapping
     public ResponseEntity<?> getSolvedHistories(

--- a/src/main/java/com/upstage/devup/user/history/dto/UserSolvedHistoryDetailDto.java
+++ b/src/main/java/com/upstage/devup/user/history/dto/UserSolvedHistoryDetailDto.java
@@ -1,0 +1,48 @@
+package com.upstage.devup.user.history.dto;
+
+import com.upstage.devup.global.entity.Question;
+import com.upstage.devup.global.entity.UserAnswer;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UserSolvedHistoryDetailDto {
+
+    private Long userId;
+
+    private Long questionId;
+    private String questionTitle;
+    private String questionText;
+    private String category;
+    private String level;
+
+    private String userAnswerText;
+
+    private LocalDateTime solvedAt;
+    private boolean isCorrect;
+
+    public static UserSolvedHistoryDetailDto of(UserAnswer entity) {
+        if (entity == null) {
+            return null;
+        }
+
+        Question question = entity.getQuestion();
+
+        return UserSolvedHistoryDetailDto.builder()
+                .userId(entity.getUser().getId())
+                .questionId(question.getId())
+                .questionTitle(question.getTitle())
+                .questionText(question.getQuestionText())
+                .category(question.getCategory().getCategory())
+                .level(question.getLevel().getLevel())
+                .userAnswerText(entity.getAnswerText())
+                .solvedAt(entity.getCreatedAt())
+                .isCorrect(entity.getIsCorrect())
+                .build();
+    }
+}

--- a/src/main/java/com/upstage/devup/user/history/dto/UserSolvedQuestionDto.java
+++ b/src/main/java/com/upstage/devup/user/history/dto/UserSolvedQuestionDto.java
@@ -1,7 +1,6 @@
-package com.upstage.devup.user.statistics.dto;
+package com.upstage.devup.user.history.dto;
 
 import com.upstage.devup.global.entity.UserAnswer;
-import com.upstage.devup.global.entity.UserAnswerStat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/upstage/devup/user/history/repository/UserSolvedHistoryRepository.java
+++ b/src/main/java/com/upstage/devup/user/history/repository/UserSolvedHistoryRepository.java
@@ -1,4 +1,4 @@
-package com.upstage.devup.user.statistics.repository;
+package com.upstage.devup.user.history.repository;
 
 import com.upstage.devup.global.entity.UserAnswer;
 import org.springframework.data.domain.Page;
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface UserAnswerHistoryRepository extends JpaRepository<UserAnswer, Long> {
+public interface UserSolvedHistoryRepository extends JpaRepository<UserAnswer, Long> {
+
     Page<UserAnswer> findByUserId(Long userId, Pageable pageable);
+
 }

--- a/src/main/java/com/upstage/devup/user/history/service/UserSolvedHistoryService.java
+++ b/src/main/java/com/upstage/devup/user/history/service/UserSolvedHistoryService.java
@@ -1,0 +1,41 @@
+package com.upstage.devup.user.history.service;
+
+import com.upstage.devup.global.exception.UnauthenticatedException;
+import com.upstage.devup.user.history.repository.UserSolvedHistoryRepository;
+import com.upstage.devup.user.history.dto.UserSolvedQuestionDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserSolvedHistoryService {
+
+    private final UserSolvedHistoryRepository userSolvedHistoryRepository;
+
+    private static final int USER_SOLVED_QUESTIONS_PER_PAGE = 10;
+
+
+    // 문제 풀이 이력 조회
+    public Page<UserSolvedQuestionDto> getUserSolvedQuestions(Long userId, Integer pageNumber) {
+        if (userId == null) {
+            throw new UnauthenticatedException("로그인이 필요합니다.");
+        }
+
+        if (pageNumber == null || pageNumber < 0) {
+            pageNumber = 0;
+        }
+
+        Sort sort = Sort.by(Sort.Direction.DESC, "createdAt");
+        Pageable pageable = PageRequest.of(pageNumber, USER_SOLVED_QUESTIONS_PER_PAGE, sort);
+
+        return userSolvedHistoryRepository
+                .findByUserId(userId, pageable)
+                .map(UserSolvedQuestionDto::of);
+    }
+}

--- a/src/main/java/com/upstage/devup/user/history/service/UserSolvedHistoryService.java
+++ b/src/main/java/com/upstage/devup/user/history/service/UserSolvedHistoryService.java
@@ -1,6 +1,9 @@
 package com.upstage.devup.user.history.service;
 
+import com.upstage.devup.global.entity.UserAnswer;
+import com.upstage.devup.global.exception.EntityNotFoundException;
 import com.upstage.devup.global.exception.UnauthenticatedException;
+import com.upstage.devup.user.history.dto.UserSolvedHistoryDetailDto;
 import com.upstage.devup.user.history.repository.UserSolvedHistoryRepository;
 import com.upstage.devup.user.history.dto.UserSolvedQuestionDto;
 import lombok.RequiredArgsConstructor;
@@ -37,5 +40,22 @@ public class UserSolvedHistoryService {
         return userSolvedHistoryRepository
                 .findByUserId(userId, pageable)
                 .map(UserSolvedQuestionDto::of);
+    }
+
+    /**
+     * 상세 문제 풀이 이력 조회
+     *
+     * @param userAnswerId 사용자 답안 ID
+     * @return 상세 문제 풀이 이력
+     */
+    public UserSolvedHistoryDetailDto getUserSolvedHistoryDetail(Long userAnswerId) {
+        if (userAnswerId == null || userAnswerId <= 0L) {
+            throw new IllegalArgumentException("풀이 이력을 찾을 수 없습니다.");
+        }
+
+        UserAnswer userAnswer = userSolvedHistoryRepository.findById(userAnswerId)
+                .orElseThrow(() -> new EntityNotFoundException("풀이 이력을 찾을 수 없습니다."));
+
+        return UserSolvedHistoryDetailDto.of(userAnswer);
     }
 }

--- a/src/main/java/com/upstage/devup/user/statistics/controller/UserStatController.java
+++ b/src/main/java/com/upstage/devup/user/statistics/controller/UserStatController.java
@@ -1,7 +1,6 @@
 package com.upstage.devup.user.statistics.controller;
 
 import com.upstage.devup.auth.config.AuthenticatedUser;
-import com.upstage.devup.user.statistics.dto.UserSolvedQuestionDto;
 import com.upstage.devup.user.statistics.dto.WrongNoteSummaryDto;
 import com.upstage.devup.user.statistics.service.UserAnswerStatService;
 import com.upstage.devup.user.statistics.service.UserWrongAnswerReadService;
@@ -21,17 +20,6 @@ public class UserStatController {
 
     private final UserAnswerStatService userAnswerStatService;
     private final UserWrongAnswerReadService userWrongAnswerReadService;
-
-    @GetMapping("/history")
-    public ResponseEntity<?> getSolvedQuestions(
-            @AuthenticationPrincipal AuthenticatedUser user,
-            @RequestParam Integer pageNumber) {
-
-        Page<UserSolvedQuestionDto> solvedQuestions
-                = userAnswerStatService.getUserSolvedQuestions(user.getUserId(), pageNumber);
-
-        return ResponseEntity.ok(solvedQuestions);
-    }
 
     @GetMapping("/wrong")
     public ResponseEntity<?> getWrongNotes(

--- a/src/main/java/com/upstage/devup/user/statistics/dto/UserSolvedQuestionDto.java
+++ b/src/main/java/com/upstage/devup/user/statistics/dto/UserSolvedQuestionDto.java
@@ -1,5 +1,6 @@
 package com.upstage.devup.user.statistics.dto;
 
+import com.upstage.devup.global.entity.UserAnswer;
 import com.upstage.devup.global.entity.UserAnswerStat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,12 +19,11 @@ public class UserSolvedQuestionDto {
     private String questionTitle;
     private String category;
     private String level;
-    private LocalDateTime firstSolvedAt;
-    private LocalDateTime lastSolvedAt;
+    private LocalDateTime solvedAt;
 
     private boolean isCorrect;
 
-    public static UserSolvedQuestionDto of(UserAnswerStat entity) {
+    public static UserSolvedQuestionDto of(UserAnswer entity) {
         if (entity == null) {
             return null;
         }
@@ -34,9 +34,8 @@ public class UserSolvedQuestionDto {
                 .questionTitle(entity.getQuestion().getTitle())
                 .category(entity.getQuestion().getCategory().getCategory())
                 .level(entity.getQuestion().getLevel().getLevel())
-                .firstSolvedAt(entity.getFirstSolvedAt())
-                .lastSolvedAt(entity.getLastSolvedAt())
-                .isCorrect(entity.getCorrectCount() > 0)
+                .solvedAt(entity.getCreatedAt())
+                .isCorrect(entity.getIsCorrect())
                 .build();
     }
 }

--- a/src/main/java/com/upstage/devup/user/statistics/repository/UserAnswerHistoryRepository.java
+++ b/src/main/java/com/upstage/devup/user/statistics/repository/UserAnswerHistoryRepository.java
@@ -1,0 +1,12 @@
+package com.upstage.devup.user.statistics.repository;
+
+import com.upstage.devup.global.entity.UserAnswer;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserAnswerHistoryRepository extends JpaRepository<UserAnswer, Long> {
+    Page<UserAnswer> findByUserId(Long userId, Pageable pageable);
+}

--- a/src/main/java/com/upstage/devup/user/statistics/service/UserAnswerStatService.java
+++ b/src/main/java/com/upstage/devup/user/statistics/service/UserAnswerStatService.java
@@ -7,6 +7,7 @@ import com.upstage.devup.user.statistics.dto.UserAnswerStatDto;
 import com.upstage.devup.user.statistics.dto.UserCategoryStatDto;
 import com.upstage.devup.user.statistics.dto.UserCategoryStatDto.CategoryStat;
 import com.upstage.devup.user.statistics.dto.UserSolvedQuestionDto;
+import com.upstage.devup.user.statistics.repository.UserAnswerHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -23,6 +24,7 @@ import java.util.List;
 public class UserAnswerStatService {
 
     private final UserAnswerStatRepository userAnswerStatRepository;
+    private final UserAnswerHistoryRepository userAnswerHistoryRepository;
     private static final int USER_SOLVED_QUESTIONS_PER_PAGE = 10;
 
     // 문제 풀이 이력 조회
@@ -35,10 +37,10 @@ public class UserAnswerStatService {
             pageNumber = 0;
         }
 
-        Sort sort = Sort.by(Sort.Direction.DESC, "firstSolvedAt");
+        Sort sort = Sort.by(Sort.Direction.DESC, "createdAt");
         Pageable pageable = PageRequest.of(pageNumber, USER_SOLVED_QUESTIONS_PER_PAGE, sort);
 
-        return userAnswerStatRepository
+        return userAnswerHistoryRepository
                 .findByUserId(userId, pageable)
                 .map(UserSolvedQuestionDto::of);
     }

--- a/src/main/java/com/upstage/devup/user/statistics/service/UserAnswerStatService.java
+++ b/src/main/java/com/upstage/devup/user/statistics/service/UserAnswerStatService.java
@@ -6,14 +6,8 @@ import com.upstage.devup.user.statistics.dto.CategoryCountDto;
 import com.upstage.devup.user.statistics.dto.UserAnswerStatDto;
 import com.upstage.devup.user.statistics.dto.UserCategoryStatDto;
 import com.upstage.devup.user.statistics.dto.UserCategoryStatDto.CategoryStat;
-import com.upstage.devup.user.statistics.dto.UserSolvedQuestionDto;
-import com.upstage.devup.user.statistics.repository.UserAnswerHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -24,27 +18,6 @@ import java.util.List;
 public class UserAnswerStatService {
 
     private final UserAnswerStatRepository userAnswerStatRepository;
-    private final UserAnswerHistoryRepository userAnswerHistoryRepository;
-    private static final int USER_SOLVED_QUESTIONS_PER_PAGE = 10;
-
-    // 문제 풀이 이력 조회
-    public Page<UserSolvedQuestionDto> getUserSolvedQuestions(Long userId, Integer pageNumber) {
-        if (userId == null) {
-            throw new UnauthenticatedException("로그인이 필요합니다.");
-        }
-
-        if (pageNumber == null || pageNumber < 0) {
-            pageNumber = 0;
-        }
-
-        Sort sort = Sort.by(Sort.Direction.DESC, "createdAt");
-        Pageable pageable = PageRequest.of(pageNumber, USER_SOLVED_QUESTIONS_PER_PAGE, sort);
-
-        return userAnswerHistoryRepository
-                .findByUserId(userId, pageable)
-                .map(UserSolvedQuestionDto::of);
-    }
-
 
     /**
      * 사용자의 문제 풀이 통계 조회

--- a/src/main/java/com/upstage/devup/web/UserSolvedHistoryViewController.java
+++ b/src/main/java/com/upstage/devup/web/UserSolvedHistoryViewController.java
@@ -1,0 +1,32 @@
+package com.upstage.devup.web;
+
+import com.upstage.devup.auth.config.AuthenticatedUser;
+import com.upstage.devup.user.history.dto.UserSolvedHistoryDetailDto;
+import com.upstage.devup.user.history.service.UserSolvedHistoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/user/history")
+@RequiredArgsConstructor
+public class UserSolvedHistoryViewController {
+
+    private final UserSolvedHistoryService userSolvedHistoryService;
+
+    @GetMapping("/{userAnswerId}")
+    public String getUserSolvedHistoryDetailView(
+            @AuthenticationPrincipal AuthenticatedUser user,
+            @PathVariable Long userAnswerId,
+            Model model
+            ) {
+        UserSolvedHistoryDetailDto result = userSolvedHistoryService.getUserSolvedHistoryDetail(userAnswerId);
+
+        model.addAttribute("history", result);
+        return "user/history/user-solved-history-detail";
+    }
+}

--- a/src/main/resources/static/css/user/history/user-solved-history-detail.css
+++ b/src/main/resources/static/css/user/history/user-solved-history-detail.css
@@ -1,0 +1,194 @@
+:root {
+    --primary-color: #2C3E50;
+    --secondary-color: #E67E22;
+    --bg-color: #F4F6FB;
+    --text-color: #2E2F3E;
+    --border-color: #DADCE5;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Segoe UI', sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+header, footer {
+    background-color: var(--primary-color);
+    color: #fff;
+    padding: 1rem 2rem;
+}
+
+header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+header nav a {
+    color: #fff;
+    margin-left: 1rem;
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.brand {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+main {
+    flex: 1;
+    padding: 2rem;
+}
+
+.container {
+    max-width: 960px;
+    margin: 0 auto;
+}
+
+.question-header {
+    margin-bottom: 1.5rem;
+}
+
+.question-header h1 {
+    font-size: 1.8rem;
+    color: var(--primary-color);
+    margin-bottom: 0.5rem;
+}
+
+.meta {
+    font-size: 0.95rem;
+    color: #555;
+    display: flex;
+    gap: 1.5rem;
+}
+
+.meta span {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+
+.question-body, .answer-body {
+    background-color: white;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    padding: 1.5rem;
+    line-height: 1.6;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.03);
+    margin-bottom: 1.5rem;
+}
+
+.question {
+    margin: 2rem 0 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.user-answer {
+    margin: 2rem 0 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.user-answer textarea {
+    padding: 1rem;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    resize: vertical;
+    font-size: 1rem;
+    line-height: 1.5;
+}
+
+.user-answer button {
+    align-self: flex-start;
+    background-color: var(--primary-color);
+    color: white;
+    border: none;
+    padding: 0.5rem 1.2rem;
+    border-radius: 4px;
+    cursor: pointer;
+    margin-top: 0.5rem;
+}
+
+.user-answer button:hover {
+    background-color: #1c2d3e;
+}
+
+.show-answer {
+    margin-bottom: 1rem;
+}
+
+.show-answer button {
+    background-color: var(--secondary-color);
+    color: white;
+    border: none;
+    padding: 0.75rem 1.5rem;
+    font-size: 1rem;
+    border-radius: 5px;
+    cursor: pointer;
+}
+
+.show-answer button:hover {
+    background-color: #cf670b;
+}
+
+.answer-body {
+    display: none;
+}
+
+.answer-body.show {
+    display: block;
+}
+
+#answer-result {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    margin-top: 1.5rem;
+}
+
+.result-btn {
+    padding: 0.5rem 1rem;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-weight: bold;
+    height: 40px;
+}
+
+.result-btn.correct {
+    background-color: #27ae60;
+    color: white;
+}
+
+.result-btn.wrong {
+    background-color: #e74c3c;
+    color: white;
+}
+
+.result-btn:hover {
+    opacity: 0.9;
+}
+
+footer {
+    text-align: center;
+    font-size: 0.9rem;
+}
+
+footer a {
+    text-decoration: none;
+    color: #ccc;
+}

--- a/src/main/resources/static/js/question/question-detail.js
+++ b/src/main/resources/static/js/question/question-detail.js
@@ -45,7 +45,7 @@ async function fetchAndShowAnswer() {
     }
 }
 
-function send(isCorrect) {
+async function send(isCorrect) {
     const userAnswer = userAnswerBox.value.trim();
 
     if (userAnswer === '') {
@@ -53,7 +53,26 @@ function send(isCorrect) {
         return;
     }
 
-    // TODO: send to server
-    console.log(userAnswer);
-    console.log(isCorrect);
+    try {
+        const response = await fetch('/api/user/answer', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                'questionId': document.getElementById('container').dataset.questionId,
+                'answerText': userAnswer,
+                'isCorrect': isCorrect
+            })
+        });
+
+        if (!response.ok) {
+            throw new Error('저장할 수 없습니다.');
+        }
+
+        const data = await response.json();
+        alert('저장됐습니다.');
+    } catch (err) {
+        alert(err);
+    }
 }

--- a/src/main/resources/static/js/user/mypage/mypage.js
+++ b/src/main/resources/static/js/user/mypage/mypage.js
@@ -96,7 +96,7 @@ async function showUserSolvedQuestions(pageNumber) {
         tbody.innerHTML = '';
         paginationEl.innerHTML = '';
 
-        const url = '/api/stat/history?pageNumber=' + pageNumber;
+        const url = '/api/user/history?pageNumber=' + pageNumber;
         const response = await fetch(url, {method: "GET"});
         const data = await response.json();
 

--- a/src/main/resources/static/js/user/mypage/mypage.js
+++ b/src/main/resources/static/js/user/mypage/mypage.js
@@ -117,7 +117,7 @@ function renderHistoryRow(item) {
 
     return `
         <td>${item.questionId}</td>
-        <td>${item.questionTitle}</td>
+        <td><a href="/user/history/${item.id}">${item.questionTitle}</a></td>
         <td>${item.category}</td>
         <td>${item.level}</td>
         <td>${formatDate(item.solvedAt)}</td>

--- a/src/main/resources/static/js/user/mypage/mypage.js
+++ b/src/main/resources/static/js/user/mypage/mypage.js
@@ -111,10 +111,6 @@ async function showUserSolvedQuestions(pageNumber) {
 }
 
 function renderHistoryRow(item) {
-    const solvedAt = item.lastSolvedAt != null
-        ? item.lastSolvedAt
-        : item.firstSolvedAt;
-
     const resultText = item.correct
         ? "<span class='tag correct'>정답</span>"
         : "<span class='tag wrong'>오답</span>";
@@ -124,7 +120,7 @@ function renderHistoryRow(item) {
         <td>${item.questionTitle}</td>
         <td>${item.category}</td>
         <td>${item.level}</td>
-        <td>${formatDate(solvedAt)}</td>
+        <td>${formatDate(item.solvedAt)}</td>
         <td>${resultText}</td>
     `;
 }

--- a/src/main/resources/templates/user/history/user-solved-history-detail.html
+++ b/src/main/resources/templates/user/history/user-solved-history-detail.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>질문 상세 - DevUp</title>
+    <link rel="stylesheet" href="/static/css/question/question-detail.css"/>
+</head>
+<body>
+
+<header id="header">
+    <div class="brand">
+        <img src="/static/images/devup_logo.png" alt="DevUp 로고" height="32"/>
+        <strong>DevUp</strong>
+    </div>
+    <nav>
+        <a href="/">홈</a>
+        <a href="#">문제풀이</a>
+        <a href="#">마이페이지</a>
+        <a href="#">로그인</a>
+    </nav>
+</header>
+
+<main>
+    <div class="container">
+
+        <div class="question-header">
+            <h1>📋 Java의 정적(static) 키워드란?</h1>
+            <div class="meta">
+                <span>📁 Java</span>
+                <span>🎯 중</span>
+                <span>🕒 2025-05-09</span>
+                <span>✅ 정답</span>
+            </div>
+        </div>
+
+        <div class="question">
+            <p><strong>📝 문제</strong></p>
+            <div class="question-body">
+                정적 키워드(static)는 클래스 수준에서 공유되는 변수를 선언할 때 사용됩니다.
+                객체가 여러 개여도 static 변수는 하나만 존재합니다.
+            </div>
+        </div>
+
+        <div class="user-answer">
+            <label for="user-answer"><strong>📝 나의 답변</strong></label>
+            <textarea id="user-answer" rows="5" placeholder="여기에 당신의 답변을 작성하세요..." readonly>사용자의 답안이 표시됩니다.</textarea>
+        </div>
+
+    </div>
+</main>
+
+<footer id="footer">
+    &copy; 2025 DevUp |
+    <a href="#">GitHub</a> |
+    이메일: support@devup.com
+</footer>
+
+</body>
+</html>

--- a/src/main/resources/templates/user/history/user-solved-history-detail.th.xml
+++ b/src/main/resources/templates/user/history/user-solved-history-detail.th.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thlogic>
+    <attr sel="head">
+        <attr sel="link" th:href="@{/css/question/question-detail.css}"/>
+    </attr>
+    <attr sel="body">
+        <attr sel="#header" th:replace="~{common/header :: header}"/>
+        <attr sel="div.question-header">
+            <attr sel="h1" th:text="'📋 ' + ${history.questionTitle}"/>
+            <attr sel="div.meta">
+                <attr sel="span[0]" th:text="'📁 ' + ${history.category}"/>
+                <attr sel="span[1]" th:text="'🎯 ' + ${history.level}"/>
+                <attr sel="span[2]" th:datetime="${history.solvedAt}"
+                      th:text="'🕒 ' + ${#temporals.format(history.solvedAt, 'yyyy-MM-dd')}"/>
+                <attr sel="span[3]" th:text="${history.isCorrect ? '✅ 정답' : '❌ 오답'}"/>
+            </attr>
+        </attr>
+        <attr sel="div.question-body" th:text="${history.questionText}"/>
+        <attr sel="#user-answer" th:text="${history.userAnswerText}"/>
+        <attr sel="#footer" th:replace="~{common/footer :: footer}"/>
+    </attr>
+</thlogic>

--- a/src/test/java/com/upstage/devup/user/answer/controller/UserAnswerSaveControllerTest.java
+++ b/src/test/java/com/upstage/devup/user/answer/controller/UserAnswerSaveControllerTest.java
@@ -50,7 +50,7 @@ class UserAnswerSaveControllerTest {
     @MockitoBean
     private JwtTokenProvider jwtTokenProvider;
 
-    private static final String URI_TEMPLATE = "/user/answer";
+    private static final String URI_TEMPLATE = "/api/user/answer";
 
     private RequestPostProcessor getAuthentication(Long userId) {
         AuthenticatedUser user = new AuthenticatedUser(userId);

--- a/src/test/java/com/upstage/devup/user/answer/controller/UserAnswerSaveControllerTest.java
+++ b/src/test/java/com/upstage/devup/user/answer/controller/UserAnswerSaveControllerTest.java
@@ -1,0 +1,306 @@
+package com.upstage.devup.user.answer.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.upstage.devup.auth.config.AuthenticatedUser;
+import com.upstage.devup.auth.config.SecurityConfig;
+import com.upstage.devup.auth.config.jwt.JwtTokenProvider;
+import com.upstage.devup.global.exception.EntityNotFoundException;
+import com.upstage.devup.user.answer.dto.UserAnswerDetailDto;
+import com.upstage.devup.user.answer.dto.UserAnswerSaveRequest;
+import com.upstage.devup.user.answer.service.UserAnswerSaveService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@Nested
+@WebMvcTest(UserAnswerSaveController.class)
+@Import(SecurityConfig.class)
+class UserAnswerSaveControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private UserAnswerSaveService userAnswerSaveService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    private static final String URI_TEMPLATE = "/user/answer";
+
+    private RequestPostProcessor getAuthentication(Long userId) {
+        AuthenticatedUser user = new AuthenticatedUser(userId);
+        Authentication auth = new UsernamePasswordAuthenticationToken(user, null, null);
+        return authentication(auth);
+    }
+
+    @Nested
+    @DisplayName("성공 케이스")
+    class SuccessCases {
+
+        @Test
+        @DisplayName("사용자 답안 저장 성공")
+        public void shouldReturnUserAnswerDetailDto_whenValidRequest() throws Exception {
+            // given
+            Long userId = 1L;
+            Long questionId = 2L;
+            String answerText = "유저 답안1";
+            Boolean isCorrect = true;
+
+            UserAnswerSaveRequest request = UserAnswerSaveRequest.builder()
+                    .questionId(questionId)
+                    .answerText(answerText)
+                    .isCorrect(isCorrect)
+                    .build();
+
+            UserAnswerDetailDto mockResult = UserAnswerDetailDto.builder()
+                    .userId(userId)
+                    .questionId(questionId)
+                    .title("제목1")
+                    .questionText("본문1")
+                    .category("JAVA")
+                    .level("중")
+                    .userAnswerId(1L)
+                    .answerText(answerText)
+                    .isCorrect(isCorrect)
+                    .createdAt(LocalDateTime.now())
+                    .build();
+
+            when(userAnswerSaveService.saveUserAnswer(eq(userId), any(UserAnswerSaveRequest.class)))
+                    .thenReturn(mockResult);
+
+            // when & then
+            String expectedCreatedAt = mockResult.getCreatedAt()
+                    .truncatedTo(ChronoUnit.SECONDS)
+                    .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+
+            mockMvc.perform(post(URI_TEMPLATE)
+                            .with(getAuthentication(userId))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType("application/json"))
+                    .andExpect(jsonPath("$.userId").value(userId))
+                    .andExpect(jsonPath("$.questionId").value(questionId))
+                    .andExpect(jsonPath("$.title").value(mockResult.getTitle()))
+                    .andExpect(jsonPath("$.questionText").value(mockResult.getQuestionText()))
+                    .andExpect(jsonPath("$.category").value(mockResult.getCategory()))
+                    .andExpect(jsonPath("$.level").value(mockResult.getLevel()))
+                    .andExpect(jsonPath("$.userAnswerId").value(mockResult.getUserAnswerId()))
+                    .andExpect(jsonPath("$.answerText").value(answerText))
+                    .andExpect(jsonPath("$.isCorrect").value(isCorrect))
+                    .andExpect(jsonPath("$.createdAt").value(expectedCreatedAt));
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 케이스")
+    class FailureCases {
+
+        @Test
+        @DisplayName("로그인하지 않은 경우")
+        public void shouldThrowUnauthenticatedException_whenUserIsNull() throws Exception {
+            // given
+            Long questionId = 2L;
+            String answerText = "유저 답안1";
+            Boolean isCorrect = true;
+
+            UserAnswerSaveRequest request = UserAnswerSaveRequest.builder()
+                    .questionId(questionId)
+                    .answerText(answerText)
+                    .isCorrect(isCorrect)
+                    .build();
+
+            // when & then
+            mockMvc.perform(post(URI_TEMPLATE)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 사용자 ID를 사용한 경우")
+        public void shouldThrowEntityNotFoundException_whenUserIsUnavailable() throws Exception {
+            // given
+            Long userId = -1L;
+            UserAnswerSaveRequest request = UserAnswerSaveRequest.builder()
+                    .questionId(2L)
+                    .answerText("유저 답안1")
+                    .isCorrect(true)
+                    .build();
+
+            when(userAnswerSaveService.saveUserAnswer(eq(userId), any(UserAnswerSaveRequest.class)))
+                    .thenThrow(new EntityNotFoundException("사용자 정보를 찾을 수 없습니다."));
+
+            // when & then
+            mockMvc.perform(post(URI_TEMPLATE)
+                            .with(getAuthentication(userId))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(content().contentType("application/json"))
+                    .andExpect(jsonPath("$.code").value("NOT_FOUND"))
+                    .andExpect(jsonPath("$.message").value("사용자 정보를 찾을 수 없습니다."));
+        }
+
+        @Test
+        @DisplayName("요청 데이터가 null 인 경우")
+        public void shouldThrowEntityNotFoundException_whenRequestIsNull() throws Exception {
+            // given
+            Long userId = 1L;
+
+            // when & then
+            mockMvc.perform(post(URI_TEMPLATE)
+                            .with(getAuthentication(userId))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(""))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("질문 ID가 null인 경우")
+        public void shouldThrowBadRequestException_whenQuestionIdIsNull() throws Exception {
+            // given
+            Long userId = 1L;
+            UserAnswerSaveRequest request = UserAnswerSaveRequest.builder()
+                    .answerText("유저 답안1")
+                    .isCorrect(true)
+                    .build();
+
+            // when & then
+            mockMvc.perform(post(URI_TEMPLATE)
+                            .with(getAuthentication(userId))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 질문 ID를 사용한 경우")
+        public void shouldThrowEntityNotFoundException_whenQuestionIdIsUnavailable() throws Exception {
+            // given
+            Long userId = 1L;
+            UserAnswerSaveRequest request = UserAnswerSaveRequest.builder()
+                    .questionId(-1L)
+                    .answerText("유저 답안1")
+                    .isCorrect(true)
+                    .build();
+
+            when(userAnswerSaveService.saveUserAnswer(eq(userId), any(UserAnswerSaveRequest.class)))
+                    .thenThrow(new EntityNotFoundException("면접 질문을 찾을 수 없습니다."));
+
+            // when & then
+            mockMvc.perform(post(URI_TEMPLATE)
+                            .with(getAuthentication(userId))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isNotFound())
+                    .andExpect(content().contentType("application/json"))
+                    .andExpect(jsonPath("$.code").value("NOT_FOUND"))
+                    .andExpect(jsonPath("$.message").value("면접 질문을 찾을 수 없습니다."));
+        }
+
+        @Test
+        @DisplayName("사용자 정답이 null인 경우")
+        public void shouldThrowBadRequestException_whenAnswerTextIsNull() throws Exception {
+            // given
+            Long userId = 1L;
+            UserAnswerSaveRequest request = UserAnswerSaveRequest.builder()
+                    .questionId(1L)
+                    .isCorrect(true)
+                    .build();
+
+            // when & then
+            mockMvc.perform(post(URI_TEMPLATE)
+                            .with(getAuthentication(userId))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("사용자 정답이 빈 값인 경우")
+        public void shouldThrowBadRequestException_whenAnswerTextIsEmpty() throws Exception {
+            // given
+            Long userId = 1L;
+            UserAnswerSaveRequest request = UserAnswerSaveRequest.builder()
+                    .questionId(1L)
+                    .answerText("")
+                    .isCorrect(true)
+                    .build();
+
+            // when & then
+            mockMvc.perform(post(URI_TEMPLATE)
+                            .with(getAuthentication(userId))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("사용자 정답이 공백으로만 이루어진 경우")
+        public void shouldThrowBadRequestException_whenAnswerTextIsBlank() throws Exception {
+            // given
+            Long userId = 1L;
+            UserAnswerSaveRequest request = UserAnswerSaveRequest.builder()
+                    .questionId(1L)
+                    .answerText("   ")
+                    .isCorrect(true)
+                    .build();
+
+            // when & then
+            mockMvc.perform(post(URI_TEMPLATE)
+                            .with(getAuthentication(userId))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("정답 유무가 null인 경우")
+        public void shouldThrowBadRequestException_whenIsCorrectIsNull() throws Exception {
+            // given
+            Long userId = 1L;
+            UserAnswerSaveRequest request = UserAnswerSaveRequest.builder()
+                    .questionId(1L)
+                    .answerText("유저 답안1")
+                    .build();
+
+            // when & then
+            mockMvc.perform(post(URI_TEMPLATE)
+                            .with(getAuthentication(userId))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+    }
+}

--- a/src/test/java/com/upstage/devup/user/history/service/UserSolvedHistoryServiceTest.java
+++ b/src/test/java/com/upstage/devup/user/history/service/UserSolvedHistoryServiceTest.java
@@ -1,7 +1,7 @@
-package com.upstage.devup.user.statistics.service;
+package com.upstage.devup.user.history.service;
 
 import com.upstage.devup.global.exception.UnauthenticatedException;
-import com.upstage.devup.user.statistics.dto.UserSolvedQuestionDto;
+import com.upstage.devup.user.history.dto.UserSolvedQuestionDto;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,10 +13,10 @@ import org.springframework.transaction.annotation.Transactional;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
-class UserSolvedQuestionReadTest {
+class UserSolvedHistoryServiceTest {
 
     @Autowired
-    private UserAnswerStatService userAnswerStatService;
+    private UserSolvedHistoryService userSolvedHistoryService;
 
     @Transactional
     @Test
@@ -27,7 +27,7 @@ class UserSolvedQuestionReadTest {
         Integer pageNumber = 0;
 
         // when
-        Page<UserSolvedQuestionDto> results = userAnswerStatService.getUserSolvedQuestions(userId, pageNumber);
+        Page<UserSolvedQuestionDto> results = userSolvedHistoryService.getUserSolvedQuestions(userId, pageNumber);
 
         // then
         assertThat(results).isNotNull();
@@ -45,7 +45,7 @@ class UserSolvedQuestionReadTest {
         Integer targetPageNumber = 0;
 
         // when
-        Page<UserSolvedQuestionDto> results = userAnswerStatService.getUserSolvedQuestions(userId, pageNumber);
+        Page<UserSolvedQuestionDto> results = userSolvedHistoryService.getUserSolvedQuestions(userId, pageNumber);
 
         // then
         assertThat(results).isNotNull();
@@ -63,7 +63,7 @@ class UserSolvedQuestionReadTest {
         Integer targetPageNumber = 0;
 
         // when
-        Page<UserSolvedQuestionDto> results = userAnswerStatService.getUserSolvedQuestions(userId, pageNumber);
+        Page<UserSolvedQuestionDto> results = userSolvedHistoryService.getUserSolvedQuestions(userId, pageNumber);
 
         // then
         assertThat(results).isNotNull();
@@ -83,7 +83,7 @@ class UserSolvedQuestionReadTest {
         // when & then
         UnauthenticatedException exception = Assertions.assertThrows(
                 UnauthenticatedException.class,
-                () -> userAnswerStatService.getUserSolvedQuestions(userId, pageNumber)
+                () -> userSolvedHistoryService.getUserSolvedQuestions(userId, pageNumber)
         );
 
         assertThat(exception.getMessage()).isEqualTo(errorMessage);

--- a/src/test/java/com/upstage/devup/user/statistics/controller/UserStatControllerTest.java
+++ b/src/test/java/com/upstage/devup/user/statistics/controller/UserStatControllerTest.java
@@ -64,8 +64,7 @@ class UserStatControllerTest {
                 .questionTitle("제목")
                 .category("카테고리")
                 .level("난이도")
-                .firstSolvedAt(LocalDateTime.now())
-                .lastSolvedAt(null)
+                .solvedAt(LocalDateTime.now())
                 .isCorrect(true)
                 .build();
 
@@ -87,8 +86,7 @@ class UserStatControllerTest {
                 .andExpect(jsonPath("$.content[0].questionTitle").value(dto.getQuestionTitle()))
                 .andExpect(jsonPath("$.content[0].category").value(dto.getCategory()))
                 .andExpect(jsonPath("$.content[0].level").value(dto.getLevel()))
-                .andExpect(jsonPath("$.content[0].firstSolvedAt").value(String.valueOf(dto.getFirstSolvedAt())))
-                .andExpect(jsonPath("$.content[0].lastSolvedAt").value(dto.getLastSolvedAt()))
+                .andExpect(jsonPath("$.content[0].firstSolvedAt").value(String.valueOf(dto.getSolvedAt())))
                 .andExpect(jsonPath("$.content[0].correct").value(String.valueOf(dto.isCorrect())))
                 .andExpect(jsonPath("$.totalElements").value(String.valueOf(items.size())));
     }

--- a/src/test/java/com/upstage/devup/user/statistics/controller/UserStatControllerTest.java
+++ b/src/test/java/com/upstage/devup/user/statistics/controller/UserStatControllerTest.java
@@ -3,7 +3,6 @@ package com.upstage.devup.user.statistics.controller;
 import com.upstage.devup.auth.config.AuthenticatedUser;
 import com.upstage.devup.auth.config.SecurityConfig;
 import com.upstage.devup.auth.config.jwt.JwtTokenProvider;
-import com.upstage.devup.user.statistics.dto.UserSolvedQuestionDto;
 import com.upstage.devup.user.statistics.dto.WrongNoteSummaryDto;
 import com.upstage.devup.user.statistics.service.UserAnswerStatService;
 import com.upstage.devup.user.statistics.service.UserWrongAnswerReadService;
@@ -48,48 +47,6 @@ class UserStatControllerTest {
 
     @MockitoBean
     private JwtTokenProvider jwtTokenProvider;
-
-    @Test
-    @DisplayName("사용자 문제 풀이 이력 조회 성공")
-    public void shouldGetSolvedQuestions() throws Exception {
-        // given
-        Long userId = 1L;
-
-        Integer pageNumber = 0;
-        int pageSize = 10;
-
-        UserSolvedQuestionDto dto = UserSolvedQuestionDto.builder()
-                .id(1L)
-                .questionId(1L)
-                .questionTitle("제목")
-                .category("카테고리")
-                .level("난이도")
-                .solvedAt(LocalDateTime.now())
-                .isCorrect(true)
-                .build();
-
-        List<UserSolvedQuestionDto> items = List.of(dto);
-        Pageable pageable = PageRequest.of(pageNumber, pageSize);
-        Page<UserSolvedQuestionDto> mockPage = new PageImpl<>(items, pageable, items.size());
-
-        when(userAnswerStatService.getUserSolvedQuestions(eq(userId), eq(pageNumber)))
-                .thenReturn(mockPage);
-
-        // when & then
-        mockMvc.perform(get("/api/stat/history")
-                        .param("pageNumber", String.valueOf(pageNumber))
-                        .with(getAuthentication(userId)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.content").isArray())
-                .andExpect(jsonPath("$.content[0].id").value(dto.getId()))
-                .andExpect(jsonPath("$.content[0].questionId").value(dto.getQuestionId()))
-                .andExpect(jsonPath("$.content[0].questionTitle").value(dto.getQuestionTitle()))
-                .andExpect(jsonPath("$.content[0].category").value(dto.getCategory()))
-                .andExpect(jsonPath("$.content[0].level").value(dto.getLevel()))
-                .andExpect(jsonPath("$.content[0].firstSolvedAt").value(String.valueOf(dto.getSolvedAt())))
-                .andExpect(jsonPath("$.content[0].correct").value(String.valueOf(dto.isCorrect())))
-                .andExpect(jsonPath("$.totalElements").value(String.valueOf(items.size())));
-    }
 
     @Test
     @DisplayName("오답 노트 목록 조회 성공")


### PR DESCRIPTION
## 작업 내용

### 풀이 이력 조회 로직 수정
- 기존 방식은 중복을 허용하지 않고 가장 최근에 풀었던 순서대로 풀이 이력을 조회함
- 정렬 기준은 그대로 두고, 중복을 허용하도록 조회 로직 수정

### 사용자 풀이 내역 상세 페이지 구현
- 풀었던 문제, 사용자 답안, 정답 유무 등이 화면에 표시됨
- 화면 조회용 API 제작(`/user/history/{questionId}`)

### 사용자 답안 저장용 API 제작(`/api/user/answer`)
- 사용자가 작성한 답안을 저장하는 서비스 클래스(`UserAnswerSaveService`)는 있었으나 컨트롤러 클래스가 없었음
- 컨트롤러(`UserAnswerSaveController`) 클래스 추가


## 참고 사항
- `user/statistics` 패키지에 있던 사용자 풀이 관련 클래스들을 `user/history` 패키지로 이동