### PR TITLE
feat: 문제 제목 검색 기능 구현

### DIFF
--- a/src/main/java/com/upstage/devup/auth/config/SecurityConfig.java
+++ b/src/main/java/com/upstage/devup/auth/config/SecurityConfig.java
@@ -28,6 +28,7 @@ public class SecurityConfig {
     };
 
     public static final String[] PUBLIC_APIS = {
+            "/api/questions/search",
             "/api/answers/**",
             "/api/auth/signin"
     };

--- a/src/main/java/com/upstage/devup/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/upstage/devup/global/handler/GlobalExceptionHandler.java
@@ -40,4 +40,11 @@ public class GlobalExceptionHandler {
                 .status(HttpStatus.UNAUTHORIZED)
                 .body(new ErrorResponse("Unauthenticated", e.getMessage()));
     }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleUnauthenticated(IllegalArgumentException e) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse("BAD_REQUEST", e.getMessage()));
+    }
 }

--- a/src/main/java/com/upstage/devup/question/controller/QuestionQueryController.java
+++ b/src/main/java/com/upstage/devup/question/controller/QuestionQueryController.java
@@ -1,0 +1,41 @@
+package com.upstage.devup.question.controller;
+
+import com.upstage.devup.question.dto.QuestionDetailDto;
+import com.upstage.devup.question.service.QuestionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/questions/search")
+@RequiredArgsConstructor
+public class QuestionQueryController {
+
+    private final QuestionService questionService;
+
+    /**
+     * 제목으로 문제 검색
+     *
+     * @param title 검색할 제목
+     * @param pageNumber 페이지 번호
+     * @return 조회된 결과
+     */
+    @GetMapping
+    public ResponseEntity<?> searchQuestionsByTitle(
+            @RequestParam String title,
+            @RequestParam(defaultValue = "0") Integer pageNumber
+    ) {
+        if (pageNumber < 0) {
+            throw new IllegalArgumentException("페이지 번호는 0 이상이어야 합니다.");
+        }
+
+        Page<QuestionDetailDto> result = questionService.searchQuestionsByTitle(title, pageNumber);
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/com/upstage/devup/question/dto/QuestionDetailDto.java
+++ b/src/main/java/com/upstage/devup/question/dto/QuestionDetailDto.java
@@ -1,5 +1,6 @@
 package com.upstage.devup.question.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -16,7 +17,11 @@ public class QuestionDetailDto {
     private String category;
     private String level;
 
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime createdAt;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime modifiedAt;
 
 }

--- a/src/main/resources/static/css/question/question-list.css
+++ b/src/main/resources/static/css/question/question-list.css
@@ -152,6 +152,12 @@ tr:hover {
     border-color: var(--secondary-color);
 }
 
+.pagination a.active:hover {
+    background-color: var(--secondary-color);
+    color: white;
+    border-color: var(--secondary-color);
+}
+
 .pagination a:hover {
     background-color: #f2f2f2;
 }

--- a/src/main/resources/static/js/question/question-list.js
+++ b/src/main/resources/static/js/question/question-list.js
@@ -1,0 +1,80 @@
+import {getPageNumbers, formatDate} from "/js/util/util.js";
+
+const searchBtn = document.getElementById('search-btn');
+searchBtn.addEventListener('click', () => search(0));
+
+async function search(pageNumber) {
+    searchBtn.disabled = true;
+
+    try {
+        const word = document.getElementById('search-input').value;
+
+        if (word === undefined || word === null || word.trim().length < 2) {
+            alert('검색어는 2자 이상이어야 합니다.');
+            return;
+        }
+
+        const response = await fetch(
+            `/api/questions/search?title=${word}&pageNumber=${pageNumber}`,
+            {method: 'GET'});
+
+        const data = await response.json();
+
+        if (!response.ok) {
+            alert(data.message);
+            return;
+        }
+
+        if (data.empty) {
+            alert('검색 결과가 없습니다. 다른 단어로 검색해주세요');
+            return;
+        }
+
+        renderSearchResult(data.content);
+        renderPagination(data.number, data.totalPages);
+    } catch (err) {
+        alert(err);
+    } finally {
+        searchBtn.disabled = false;
+    }
+}
+
+function renderSearchResult(content) {
+    const tbody = document.getElementById("table-body");
+    tbody.innerHTML = '';
+
+    content.forEach(item => {
+        const row = document.createElement('tr');
+        row.innerHTML = `
+            <td class="q_no">${item.id}</td>
+            <td class="q_title"><a href="/questions/${item.id}">${item.title}</a></td>
+            <td class="q_category">${item.category}</td>
+            <td class="q_level">${item.level}</td>
+            <td class="q_created_at">${formatDate(item.createdAt)}</td>
+        `;
+
+        tbody.appendChild(row);
+    });
+}
+
+function renderPagination(currentPage, totalPages) {
+    const paginationEl = document.getElementById("pagination");
+    paginationEl.innerHTML = '';
+
+    const pageNumbers = getPageNumbers(currentPage, totalPages);
+    pageNumbers.forEach(page => {
+        const a = document.createElement("a");
+        a.textContent = page + 1;
+
+        if (page === currentPage) {
+            a.classList.add("active");
+        } else {
+            a.addEventListener("click", () => search(page));
+        }
+
+        const div = document.createElement("div");
+        div.appendChild(a);
+
+        paginationEl.appendChild(div);
+    });
+}

--- a/src/main/resources/static/js/util/util.js
+++ b/src/main/resources/static/js/util/util.js
@@ -1,0 +1,39 @@
+// 페이징 처리 시 표시할 페이지 번호 확인
+export function getPageNumbers(currentPage, totalPages, maxPages = 5) {
+    if (totalPages === 0) {
+        return [];
+    }
+
+    const pages = [];
+
+    // 페이지 번호는 0부터 시작
+    const half = Math.floor(maxPages / 2);
+    let start = Math.max(0, currentPage - half);
+    let end = start + maxPages;
+
+    // 범위를 초과하면 조정
+    if (end > totalPages) {
+        end = totalPages;
+        start = Math.max(0, end - maxPages);
+    }
+
+    for (let i = start; i < end; i++) {
+        pages.push(i);
+    }
+
+    return pages;
+}
+
+export function formatDate(dateStr) {
+    if (dateStr === undefined || dateStr === null) {
+        return "";
+    }
+
+    const date = new Date(dateStr);
+
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+
+    return `${year}-${month}-${day}`;
+}

--- a/src/main/resources/templates/question/question-list.html
+++ b/src/main/resources/templates/question/question-list.html
@@ -25,7 +25,7 @@
         <div class="header-row">
             <h1 aria-label="문제 목록">📋 문제 목록</h1>
             <div class="search-bar">
-                <input type="text" placeholder="제목으로 검색..."/>
+                <input id="search-input" type="text" placeholder="제목으로 검색..."/>
                 <button id="search-btn">검색</button>
             </div>
         </div>
@@ -40,7 +40,7 @@
                 <th>작성일</th>
             </tr>
             </thead>
-            <tbody>
+            <tbody id="table-body">
             <tr>
                 <td class="q_no">1</td>
                 <td class="q_title">
@@ -131,6 +131,8 @@
     <a href="#">GitHub</a> |
     이메일: support@devup.com
 </footer>
+
+<script id="main-script" type="module" src="/static/js/question/question-list.js"></script>
 
 </body>
 </html>

--- a/src/main/resources/templates/question/question-list.th.xml
+++ b/src/main/resources/templates/question/question-list.th.xml
@@ -31,5 +31,6 @@
             </attr>
         </attr>
         <attr sel="#footer" th:replace="~{common/footer :: footer}"/>
+        <attr sel="#main-script" th:src="@{/js/question/question-list.js}"/>
     </attr>
 </thlogic>

--- a/src/test/java/com/upstage/devup/question/controller/QuestionQueryControllerTest.java
+++ b/src/test/java/com/upstage/devup/question/controller/QuestionQueryControllerTest.java
@@ -1,0 +1,258 @@
+package com.upstage.devup.question.controller;
+
+import com.upstage.devup.auth.config.SecurityConfig;
+import com.upstage.devup.auth.config.jwt.JwtTokenProvider;
+import com.upstage.devup.question.dto.QuestionDetailDto;
+import com.upstage.devup.question.service.QuestionService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@Nested
+@WebMvcTest(QuestionQueryController.class)
+@Import(SecurityConfig.class)
+@DisplayName("면접 질문 제목 검색 테스트")
+class QuestionQueryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private QuestionService questionService;
+
+    private static final String URI_TEMPLATE = "/api/questions/search";
+
+    private QuestionDetailDto createSampleDto() {
+        return QuestionDetailDto.builder()
+                .id(1L)
+                .title("OOP란?")
+                .questionText("OOP가 무엇인지 설명하세요.")
+                .category("JAVA")
+                .level("하")
+                .createdAt(LocalDateTime.now())
+                .modifiedAt(null)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("성공 케이스")
+    public class SuccessCases {
+
+        @Test
+        @DisplayName("유효한 요청 데이터가 넘어온 경우")
+        public void shouldReturnPages_whenRequestIsValid() throws Exception {
+            // given
+            String title = "란?";
+            int pageNumber = 0;
+            int pageSize = 10;
+            Sort sort = Sort.by(Sort.Direction.DESC, "createdAt");
+
+            QuestionDetailDto sample = createSampleDto();
+            List<QuestionDetailDto> items = List.of(sample);
+            Page<QuestionDetailDto> mockPage = new PageImpl<>(
+                    items,
+                    PageRequest.of(pageNumber, pageSize, sort),
+                    items.size()
+            );
+
+            when(questionService.searchQuestionsByTitle(eq(title), eq(pageNumber)))
+                    .thenReturn(mockPage);
+
+            // when & then
+            String expectedCreatedAt = sample.getCreatedAt()
+                    .truncatedTo(ChronoUnit.SECONDS)
+                    .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+
+            mockMvc.perform(get(URI_TEMPLATE)
+                            .param("title", title)
+                            .param("pageNumber", String.valueOf(pageNumber)))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.totalElements").value(1))
+                    .andExpect(jsonPath("$.number").value(pageNumber))
+                    .andExpect(jsonPath("$.first").value(true))
+                    .andExpect(jsonPath("$.size").value(pageSize))
+                    .andExpect(jsonPath("$.content").isArray())
+                    .andExpect(jsonPath("$.content[0].id").value(sample.getId()))
+                    .andExpect(jsonPath("$.content[0].title").value(sample.getTitle()))
+                    .andExpect(jsonPath("$.content[0].questionText").value(sample.getQuestionText()))
+                    .andExpect(jsonPath("$.content[0].category").value(sample.getCategory()))
+                    .andExpect(jsonPath("$.content[0].level").value(sample.getLevel()))
+                    .andExpect(jsonPath("$.content[0].createdAt").value(expectedCreatedAt))
+                    .andExpect(jsonPath("$.content[0].modifiedAt").value(nullValue()));
+        }
+
+        @Test
+        @DisplayName("pageNumber가 null로 전달된 경우, defaultValue인 0으로 처리된다")
+        public void shouldReturnPage_whenPageNumberIsNull() throws Exception {
+            // given
+            String title = "검색어";
+            int pageSize = 10;
+
+            QuestionDetailDto sample = createSampleDto();
+            List<QuestionDetailDto> items = List.of(sample);
+            Sort sort = Sort.by(Sort.Direction.DESC, "createdAt");
+            Page<QuestionDetailDto> mockPage = new PageImpl<>(
+                    items,
+                    PageRequest.of(0, pageSize, sort),
+                    items.size()
+            );
+
+            when(questionService.searchQuestionsByTitle(eq(title), eq(0)))
+                    .thenReturn(mockPage);
+
+            // when & then
+            String expectedCreatedAt = sample.getCreatedAt()
+                    .truncatedTo(ChronoUnit.SECONDS)
+                    .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+
+            mockMvc.perform(get(URI_TEMPLATE)
+                            .param("title", title))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.totalElements").value(1))
+                    .andExpect(jsonPath("$.number").value(0))
+                    .andExpect(jsonPath("$.first").value(true))
+                    .andExpect(jsonPath("$.size").value(pageSize))
+                    .andExpect(jsonPath("$.content").isArray())
+                    .andExpect(jsonPath("$.content[0].id").value(sample.getId()))
+                    .andExpect(jsonPath("$.content[0].title").value(sample.getTitle()))
+                    .andExpect(jsonPath("$.content[0].questionText").value(sample.getQuestionText()))
+                    .andExpect(jsonPath("$.content[0].category").value(sample.getCategory()))
+                    .andExpect(jsonPath("$.content[0].level").value(sample.getLevel()))
+                    .andExpect(jsonPath("$.content[0].createdAt").value(expectedCreatedAt))
+                    .andExpect(jsonPath("$.content[0].modifiedAt").value(nullValue()));
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 케이스 - 유효하지 않은 검색어")
+    public class FailureCasesUsingUnavailableTitle {
+
+        @Test
+        @DisplayName("검색어가 null인 경우")
+        public void shouldReturnEmptyPage_whenTitleIsNull() throws Exception {
+            // given
+            int pageNumber = 0;
+
+            // when & then
+            mockMvc.perform(get(URI_TEMPLATE)
+                            .param("pageNumber", String.valueOf(pageNumber)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("검색어를 입력하지 않은 경우")
+        public void shouldReturnEmptyPage_whenTitleIsEmpty() throws Exception {
+            // given
+            String title = "";
+            int pageNumber = 0;
+            int pageSize = 10;
+            Sort sort = Sort.by(Sort.Direction.DESC, "createdAt");
+
+            Page<QuestionDetailDto> mockPage = new PageImpl<>(
+                    List.of(),
+                    PageRequest.of(pageNumber, pageSize, sort),
+                    0
+            );
+
+            when(questionService.searchQuestionsByTitle(eq(title), eq(pageNumber)))
+                    .thenReturn(mockPage);
+
+            // when & then
+            mockMvc.perform(get(URI_TEMPLATE)
+                            .param("title", title)
+                            .param("pageNumber", String.valueOf(pageNumber)))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.empty").value(true))
+                    .andExpect(jsonPath("$.content").isArray())
+                    .andExpect(jsonPath("$.content").isEmpty())
+                    .andExpect(jsonPath("totalPages").value(0))
+                    .andExpect(jsonPath("$.totalElements").value(0))
+                    .andExpect(jsonPath("$.first").value(true))
+                    .andExpect(jsonPath("$.number").value(pageNumber))
+                    .andExpect(jsonPath("$.size").value(pageSize));
+        }
+
+        @Test
+        @DisplayName("검색어 길이가 2보다 작은 경우")
+        public void shouldReturnEmptyPage_whenTitleLengthIsLessThan2() throws Exception {
+            // given
+            String title = "일";
+            int pageNumber = 0;
+            int pageSize = 10;
+            Sort sort = Sort.by(Sort.Direction.DESC, "createdAt");
+
+            Page<QuestionDetailDto> mockPage = new PageImpl<>(
+                    List.of(),
+                    PageRequest.of(pageNumber, pageSize, sort),
+                    0
+            );
+
+            when(questionService.searchQuestionsByTitle(eq(title), eq(pageNumber)))
+                    .thenReturn(mockPage);
+
+            // when & then
+            mockMvc.perform(get(URI_TEMPLATE)
+                            .param("title", title)
+                            .param("pageNumber", String.valueOf(pageNumber)))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.empty").value(true))
+                    .andExpect(jsonPath("$.content").isArray())
+                    .andExpect(jsonPath("$.content").isEmpty())
+                    .andExpect(jsonPath("totalPages").value(0))
+                    .andExpect(jsonPath("$.totalElements").value(0))
+                    .andExpect(jsonPath("$.first").value(true))
+                    .andExpect(jsonPath("$.number").value(pageNumber))
+                    .andExpect(jsonPath("$.size").value(pageSize));
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 케이스 - 유효하지 않은 페이지 번호")
+    public class FailureCasesUsingUnavailablePageNumber {
+
+        @Test
+        @DisplayName("페이지 번호가 음수인 경우")
+        public void shouldReturn400_whenPageNumberIsNegative() throws Exception {
+            // given
+            String title = "검색어";
+            Integer pageNumber = -1;
+
+            // when & then
+            mockMvc.perform(get(URI_TEMPLATE)
+                            .param("title", title)
+                            .param("pageNumber", String.valueOf(pageNumber)))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+}


### PR DESCRIPTION
## 작업 내용

### 문제 제목 검색용 API 제작(`/api/questions/search`)
- API 사용 시 검색할 제목, 페이지 번호 필요
- 두 글자 미만의 검색어로 검색 시 빈 페이지 반환
- 페이지 번호가 음수인 경우 `IllegalArgumentException` 예외 발생
- `SecurityConfig` 클래스에 예외 경로 등록
- 테스트 코드 작성 및 통과 확인

### 문제 목록 화면에 제목 검색 기능 연결
- 에러 발생 시 메시지와 함께 모달창이 나타나도록 제작
- 페이징 처리


## 참고 사항
- `util.js` 파일을 제작해 `getPageNumbers`, `formatDate`와 같은 공용 메서드들을 모아둠