### PR TITLE
feat: 오답노트 삭제 기능 구현

### DIFF
--- a/src/main/java/com/upstage/devup/user/wrong/controller/UserWrongNoteDeleteController.java
+++ b/src/main/java/com/upstage/devup/user/wrong/controller/UserWrongNoteDeleteController.java
@@ -1,0 +1,37 @@
+package com.upstage.devup.user.wrong.controller;
+
+import com.upstage.devup.auth.config.AuthenticatedUser;
+import com.upstage.devup.global.exception.EntityNotFoundException;
+import com.upstage.devup.user.wrong.service.UserWrongNoteDeleteService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/wrong")
+@RequiredArgsConstructor
+public class UserWrongNoteDeleteController {
+
+    private final UserWrongNoteDeleteService userWrongNoteDeleteService;
+
+    /**
+     * 오답노트 삭제
+     *
+     * @param user       로그인한 사용자 정보
+     * @param questionId 삭제할 오답노트의 질문 ID
+     * @throws EntityNotFoundException 조회된 오답노트가 없는 경우 발생
+     */
+    @DeleteMapping("/{questionId}")
+    public ResponseEntity<Void> deleteWrongNote(
+            @AuthenticationPrincipal AuthenticatedUser user,
+            @PathVariable Long questionId
+    ) {
+        userWrongNoteDeleteService.deleteWrongNote(user.getUserId(), questionId);
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/src/main/java/com/upstage/devup/user/wrong/controller/UserWrongNoteQueryController.java
+++ b/src/main/java/com/upstage/devup/user/wrong/controller/UserWrongNoteQueryController.java
@@ -1,9 +1,8 @@
-package com.upstage.devup.user.statistics.controller;
+package com.upstage.devup.user.wrong.controller;
 
 import com.upstage.devup.auth.config.AuthenticatedUser;
 import com.upstage.devup.user.statistics.dto.WrongNoteSummaryDto;
-import com.upstage.devup.user.statistics.service.UserAnswerStatService;
-import com.upstage.devup.user.statistics.service.UserWrongAnswerReadService;
+import com.upstage.devup.user.wrong.service.UserWrongAnswerQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
@@ -14,21 +13,25 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/stat")
+@RequestMapping("/api/wrong")
 @RequiredArgsConstructor
-public class UserStatController {
+public class UserWrongNoteQueryController {
 
-    private final UserAnswerStatService userAnswerStatService;
-    private final UserWrongAnswerReadService userWrongAnswerReadService;
+    private final UserWrongAnswerQueryService userWrongAnswerQueryService;
 
-    @GetMapping("/wrong")
+    @GetMapping
     public ResponseEntity<?> getWrongNotes(
             @AuthenticationPrincipal AuthenticatedUser user,
-            @RequestParam Integer pageNumber) {
+            @RequestParam(defaultValue = "0") Integer pageNumber
+    ) {
 
-        Page<WrongNoteSummaryDto> summaries
-                = userWrongAnswerReadService.getWrongNoteSummaries(user.getUserId(), pageNumber);
+        if (pageNumber < 0) {
+            throw new IllegalArgumentException("페이지 번호는 0 이상이어야 합니다.");
+        }
 
-        return ResponseEntity.ok(summaries);
+        Page<WrongNoteSummaryDto> result
+                = userWrongAnswerQueryService.getWrongNoteSummaries(user.getUserId(), pageNumber);
+
+        return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/com/upstage/devup/user/wrong/repository/UserWrongNoteRepository.java
+++ b/src/main/java/com/upstage/devup/user/wrong/repository/UserWrongNoteRepository.java
@@ -1,0 +1,14 @@
+package com.upstage.devup.user.wrong.repository;
+
+import com.upstage.devup.global.entity.UserWrongAnswer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserWrongNoteRepository extends JpaRepository<UserWrongAnswer, Long> {
+
+    void deleteByUserIdAndQuestionId(long userId, long questionId);
+
+    boolean existsByUserIdAndQuestionId(long userId, long questionId);
+
+}

--- a/src/main/java/com/upstage/devup/user/wrong/service/UserWrongAnswerQueryService.java
+++ b/src/main/java/com/upstage/devup/user/wrong/service/UserWrongAnswerQueryService.java
@@ -1,4 +1,4 @@
-package com.upstage.devup.user.statistics.service;
+package com.upstage.devup.user.wrong.service;
 
 import com.upstage.devup.global.exception.EntityNotFoundException;
 import com.upstage.devup.global.entity.Question;
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Service;
 @Service
 @Slf4j
 @RequiredArgsConstructor
-public class UserWrongAnswerReadService {
+public class UserWrongAnswerQueryService {
 
     private final UserWrongAnswerRepository userWrongAnswerRepository;
 
@@ -33,17 +33,13 @@ public class UserWrongAnswerReadService {
      * @throws EntityNotFoundException  사용자 ID가 null일 때 발생
      * @throws IllegalArgumentException pageNumber가 null이거나 음수일 때 발생
      */
-    public Page<WrongNoteSummaryDto> getWrongNoteSummaries(Long userId, Integer pageNumber) {
-        if (userId == null) {
-            throw new EntityNotFoundException("사용자 정보를 찾을 수 없습니다.");
-        }
+    public Page<WrongNoteSummaryDto> getWrongNoteSummaries(long userId, int pageNumber) {
 
-        if (pageNumber == null) {
-            throw new IllegalArgumentException("오답 노트를 불러올 수 없습니다.");
-        }
-
-        Sort sort = Sort.by(Sort.Direction.DESC, "createdAt");
-        Pageable pageable = PageRequest.of(pageNumber, WRONG_NOTES_PER_PAGE, sort);
+        Pageable pageable = PageRequest.of(
+                pageNumber,
+                WRONG_NOTES_PER_PAGE,
+                Sort.by(Sort.Direction.DESC, "createdAt")
+        );
 
         return userWrongAnswerRepository
                 .findByUserId(userId, pageable)

--- a/src/main/java/com/upstage/devup/user/wrong/service/UserWrongNoteDeleteService.java
+++ b/src/main/java/com/upstage/devup/user/wrong/service/UserWrongNoteDeleteService.java
@@ -1,0 +1,26 @@
+package com.upstage.devup.user.wrong.service;
+
+import com.upstage.devup.global.exception.EntityNotFoundException;
+import com.upstage.devup.user.wrong.repository.UserWrongNoteRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserWrongNoteDeleteService {
+
+    private final UserWrongNoteRepository userWrongNoteRepository;
+
+    @Transactional
+    public void deleteWrongNote(long userId, long questionId) {
+        if (!userWrongNoteRepository.existsByUserIdAndQuestionId(userId, questionId)) {
+            throw new EntityNotFoundException("오답노트를 찾을 수 없습니다.");
+        }
+
+        userWrongNoteRepository.deleteByUserIdAndQuestionId(userId, questionId);
+    }
+
+}

--- a/src/main/java/com/upstage/devup/web/MyPageViewController.java
+++ b/src/main/java/com/upstage/devup/web/MyPageViewController.java
@@ -4,7 +4,6 @@ import com.upstage.devup.auth.config.AuthenticatedUser;
 import com.upstage.devup.user.statistics.dto.UserAnswerStatDto;
 import com.upstage.devup.user.statistics.dto.UserCategoryStatDto;
 import com.upstage.devup.user.statistics.service.UserAnswerStatService;
-import com.upstage.devup.user.statistics.service.UserWrongAnswerReadService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
@@ -18,7 +17,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class MyPageViewController {
 
     private final UserAnswerStatService userAnswerStatService;
-    private final UserWrongAnswerReadService userWrongAnswerReadService;
 
     /**
      * 마이페이지 화면 불러오기

--- a/src/main/resources/static/css/user/mypage/mypage.css
+++ b/src/main/resources/static/css/user/mypage/mypage.css
@@ -165,10 +165,12 @@ tr:hover {
 .delete-btn:hover {
     font-size: 1rem;
     background: #e85c4f;
+    cursor: pointer;
 }
 
 .delete-btn:disabled {
     background: #ffc6b9;
+    cursor: pointer;
 }
 
 .pagination {
@@ -188,6 +190,7 @@ tr:hover {
     background-color: var(--secondary-color);
     color: white;
     border-color: var(--secondary-color);
+    cursor: pointer;
 }
 
 .pagination button:disabled {

--- a/src/main/resources/static/css/user/mypage/mypage.css
+++ b/src/main/resources/static/css/user/mypage/mypage.css
@@ -153,6 +153,24 @@ tr:hover {
     border-radius: 4px;
 }
 
+.delete-btn {
+    font-size: 1rem;
+    background: #ff6f61;
+    color: white;
+    padding: 0.3rem 0.6rem;
+    border-radius: 4px;
+    border: 1px solid;
+}
+
+.delete-btn:hover {
+    font-size: 1rem;
+    background: #e85c4f;
+}
+
+.delete-btn:disabled {
+    background: #ffc6b9;
+}
+
 .pagination {
     margin-top: 1rem;
     text-align: center;

--- a/src/main/resources/static/js/user/mypage/mypage-test.js
+++ b/src/main/resources/static/js/user/mypage/mypage-test.js
@@ -1,0 +1,39 @@
+const tabContainer = document.getElementById('tab-container');
+let currentTabButton = null;
+
+document.addEventListener('DOMContentLoaded', () => {
+    currentTabButton = document.getElementById("stats-tab-btn");
+    showTab('stats');
+});
+
+document.querySelectorAll(".tab-button").forEach(btn => {
+    btn.addEventListener("click", () => {
+        changeCurrentTabButton(btn);
+        showTab(btn.dataset.tab);
+    });
+});
+
+// 탭 버튼 바꾸기
+function changeCurrentTabButton(btn) {
+    if (currentTabButton !== null) {
+        currentTabButton.classList.remove('active');
+    }
+
+    btn.classList.add('active');
+    currentTabButton = btn;
+}
+
+// 탭 전환하기
+function showTab(tabName) {
+    tabContainer.innerHTML = '';
+
+    const template = document.getElementById(tabName);
+
+    if (template) {
+        const content = template.content.cloneNode(true);
+        tabContainer.appendChild(content);
+    } else {
+        alert(`${tabName} 탭을 찾을 수 없습니다.`);
+    }
+
+}

--- a/src/main/resources/static/js/user/mypage/mypage-wrong-note.js
+++ b/src/main/resources/static/js/user/mypage/mypage-wrong-note.js
@@ -110,5 +110,18 @@ function addDeleteButtonClickHandler() {
 }
 
 async function deleteWrongNote(questionId) {
-    console.log('오답노트 삭제: ' + questionId);
+    try {
+        const response = await fetch(`/api/wrong/${questionId}`, {
+            method: 'DELETE'
+        });
+
+        if (response.ok) {
+            alert('오답노트를 삭제했습니다.');
+             await showWrongNote(0);
+        } else {
+            alert('오답노트를 삭제할 수 없습니다.');
+        }
+    } catch (err) {
+        alert(err);
+    }
 }

--- a/src/main/resources/static/js/user/mypage/mypage-wrong-note.js
+++ b/src/main/resources/static/js/user/mypage/mypage-wrong-note.js
@@ -1,0 +1,114 @@
+import {formatDate, getPageNumbers} from "/js/util/util.js";
+
+/**
+ * 오답 노트 목록 보여주기
+ *
+ * @param pageNumber 페이지 번호
+ * @returns {Promise<void>}
+ */
+export async function showWrongNote(pageNumber) {
+    try {
+        const tbody = document.getElementById('wrong-body');
+        const paginationEl = document.getElementById('wrong-pagination');
+        tbody.innerHTML = '';
+        paginationEl.innerHTML = '';
+
+        const data = await fetchWrongNote(pageNumber);
+
+        // 오답 노트 목록 보여주기
+        renderWrongNoteTable(data, tbody);
+
+        // 페이징 처리
+        renderPagination(data, paginationEl);
+
+        // 삭제 버튼에 이벤트 할당
+        addDeleteButtonClickHandler();
+    } catch (err) {
+        alert(err);
+    }
+}
+
+/**
+ * 서버에 오답노트 데이터 요청하기
+ *
+ * @param pageNumber 페이지 번호
+ * @returns {Promise<any>}
+ */
+async function fetchWrongNote(pageNumber) {
+    const url = '/api/wrong?pageNumber=' + pageNumber;
+    const response = await fetch(url, {
+        method: "GET"
+    });
+
+    if (!response.ok) {
+        throw new Error('오답노트를 불러오는 데 실패했습니다.');
+    }
+
+    return await response.json();
+}
+
+/**
+ * 오답노트 테이블 렌더링
+ *
+ * @param data 서버에서 받은 오답노트 데이터
+ * @param tbody 테이블 tbody 요소
+ */
+function renderWrongNoteTable(data, tbody) {
+    data.content.forEach(item => {
+        const row = document.createElement('tr');
+        row.innerHTML = `
+                <td>${item.questionId}</td>
+                <td><a href="/questions/${item.questionId}">${item.title}</a></td>
+                <td>${item.category}</td>
+                <td>${item.level}</td>
+                <td>${formatDate(item.createdAt)}</td>
+                <td>
+                    <button class="delete-btn" data-question-id="${item.questionId}">
+                        <span>삭제</span>
+                    </button>
+                </td>
+            `;
+
+        tbody.appendChild(row);
+    })
+}
+
+/**
+ * 오답노트 페이징 처리
+ *
+ * @param data 오답노트 데이터
+ * @param paginationEl
+ */
+function renderPagination(data, paginationEl) {
+    const pageNumbers = getPageNumbers(data.number, data.totalPages);
+
+    pageNumbers.forEach(page => {
+        const btn = document.createElement("button");
+        btn.textContent = page + 1;
+
+        if (page === data.number) {
+            btn.classList.add("active");
+            btn.disabled = true;
+        }
+
+        btn.addEventListener("click", () => showWrongNote(page));
+
+        paginationEl.appendChild(btn);
+    });
+}
+
+/**
+ * [삭제] 버튼에 이벤트 할당하기
+ */
+function addDeleteButtonClickHandler() {
+    const buttons = document.querySelectorAll(".delete-btn");
+
+    buttons.forEach(button => {
+        const questionId = button.getAttribute('data-question-id');
+        button.addEventListener('click', () => deleteWrongNote(questionId));
+    })
+}
+
+async function deleteWrongNote(questionId) {
+    console.log('오답노트 삭제: ' + questionId);
+}

--- a/src/main/resources/static/js/user/mypage/mypage.js
+++ b/src/main/resources/static/js/user/mypage/mypage.js
@@ -1,12 +1,12 @@
 import {showProfile} from '/js/user/mypage/mypage-profile.js';
+import {showWrongNote} from '/js/user/mypage/mypage-wrong-note.js';
 
 const tabContainer = document.getElementById('tab-container');
 const buttons = document.querySelectorAll(".tab-button");
 let currentTabButton = null;
 
 const tabActionMap = {
-    stats: () => {
-    },
+    stats: () => {},
     history: () => showUserSolvedQuestions(0),
     wrong: () => showWrongNote(0),
     profile: showProfile
@@ -14,13 +14,13 @@ const tabActionMap = {
 
 document.addEventListener('DOMContentLoaded', () => {
     currentTabButton = document.getElementById("stats-tab-btn");
-    showTab('stats');
+    changeTab('stats');
 });
 
 buttons.forEach(btn => {
     btn.addEventListener("click", () => {
         changeCurrentTabButton(btn);
-        showTab(btn.dataset.tab);
+        changeTab(btn.dataset.tab);
     });
 });
 
@@ -35,57 +35,25 @@ function changeCurrentTabButton(btn) {
 }
 
 // 탭 전환하기
-async function showTab(tabName) {
+async function changeTab(tabName) {
     tabContainer.innerHTML = "";
     tabContainer.innerHTML = "데이터를 불러오는 중입니다.";
 
-    const template = document.getElementById(tabName);
+    const tabTemplate = document.getElementById(tabName);
 
-    if (!template) {
+    if (!tabTemplate) {
         return;
     }
 
     tabContainer.innerHTML = "";
 
-    const content = template.content.cloneNode(true);
-    tabContainer.appendChild(content);
+    const clonedTemplate = tabTemplate.content.cloneNode(true);
+    tabContainer.appendChild(clonedTemplate);
 
     const action = tabActionMap[tabName];
     if (typeof action === 'function') {
         await action();
     }
-}
-
-// 오답 노트 목록 보여주기
-async function showWrongNote(pageNumber) {
-    try {
-        const tbody = document.getElementById('wrong-body');
-        const paginationEl = document.getElementById('wrong-pagination');
-        tbody.innerHTML = '';
-        paginationEl.innerHTML = '';
-
-        const url = '/api/wrong?pageNumber=' + pageNumber;
-        const response = await fetch(url, {method: "GET"});
-        const data = await response.json();
-
-        // 오답 노트 목록 보여주기
-        renderTable(data.content, tbody, renderWrongNoteRow);
-
-        // 페이징 처리
-        renderPagination(data.number, data.totalPages, paginationEl, showWrongNote);
-    } catch (err) {
-        alert(err);
-    }
-}
-
-function renderWrongNoteRow(item) {
-    return `
-        <td>${item.questionId}</td>
-        <td>${item.title}</td>
-        <td>${item.category}</td>
-        <td>${item.level}</td>
-        <td>${formatDate(item.createdAt)}</td>
-        `;
 }
 
 // 풀이 이력 목록 보여주기

--- a/src/main/resources/static/js/user/mypage/mypage.js
+++ b/src/main/resources/static/js/user/mypage/mypage.js
@@ -64,7 +64,7 @@ async function showWrongNote(pageNumber) {
         tbody.innerHTML = '';
         paginationEl.innerHTML = '';
 
-        const url = '/api/stat/wrong?pageNumber=' + pageNumber;
+        const url = '/api/wrong?pageNumber=' + pageNumber;
         const response = await fetch(url, {method: "GET"});
         const data = await response.json();
 

--- a/src/main/resources/templates/user/mypage/mypage.html
+++ b/src/main/resources/templates/user/mypage/mypage.html
@@ -148,7 +148,7 @@
     이메일: devup@devup.com
 </footer>
 
-<script id="main-script" type="module" src="/static/js/user/mypage/mypage.js"></script>
+<script id="main-script" type="module" src="/static/js/user/mypage/mypage-test.js"></script>
 
 </body>
 </html>

--- a/src/main/resources/templates/user/mypage/mypage.html
+++ b/src/main/resources/templates/user/mypage/mypage.html
@@ -77,9 +77,9 @@
         </tbody>
     </table>
     <div class="pagination" id="history-pagination">
-        <a>1</a>
-        <a>2</a>
-        <a>3</a>
+        <button class="active">1</button>
+        <button>2</button>
+        <button>3</button>
     </div>
 </template>
 <template class="tab-content" id="wrong">
@@ -91,6 +91,7 @@
             <th>카테고리</th>
             <th>난이도</th>
             <th>날짜</th>
+            <th>삭제</th>
         </tr>
         </thead>
         <tbody id="wrong-body">
@@ -100,13 +101,22 @@
             <td>DB</td>
             <td>상</td>
             <td>2025-05-08</td>
+            <td><button class="delete-btn" disabled><span>삭제</span></button></td>
+        </tr>
+        <tr>
+            <td>1</td>
+            <td>OOP란?</td>
+            <td>JAVA</td>
+            <td>하</td>
+            <td>2025-05-08</td>
+            <td><button class="delete-btn"><span>삭제</span></button></td>
         </tr>
         </tbody>
     </table>
     <div class="pagination" id="wrong-pagination">
-        <a>1</a>
-        <a>2</a>
-        <a>3</a>
+        <button class="active">1</button>
+        <button>2</button>
+        <button>3</button>
     </div>
 </template>
 <template class="tab-content" id="profile">

--- a/src/test/java/com/upstage/devup/user/wrong/controller/UserWrongNoteDeleteControllerTest.java
+++ b/src/test/java/com/upstage/devup/user/wrong/controller/UserWrongNoteDeleteControllerTest.java
@@ -1,0 +1,100 @@
+package com.upstage.devup.user.wrong.controller;
+
+import com.upstage.devup.auth.config.AuthenticatedUser;
+import com.upstage.devup.auth.config.SecurityConfig;
+import com.upstage.devup.auth.config.jwt.JwtTokenProvider;
+import com.upstage.devup.global.exception.EntityNotFoundException;
+import com.upstage.devup.user.wrong.service.UserWrongNoteDeleteService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserWrongNoteDeleteController.class)
+@Import(SecurityConfig.class)
+class UserWrongNoteDeleteControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private UserWrongNoteDeleteService userWrongNoteDeleteService;
+
+    private static final String URI_TEMPLATE = "/api/wrong/";
+
+    private RequestPostProcessor getAuthentication(Long userId) {
+        AuthenticatedUser user = new AuthenticatedUser(userId);
+        Authentication auth = new UsernamePasswordAuthenticationToken(user, null, null);
+        return authentication(auth);
+    }
+
+    @Nested
+    @DisplayName("성공 테스트")
+    public class SuccessCases {
+
+        @Test
+        @DisplayName("DB에 오답노트가 있는 경우 200 OK 응답")
+        public void shouldReturn200_whenUserWrongAnswerExistsInDB() throws Exception {
+            // given
+            long userId = 1L;
+            long questionId = 2L;
+
+            // when & then
+            mockMvc.perform(delete(URI_TEMPLATE + questionId)
+                            .with(getAuthentication(userId)))
+                    .andDo(print())
+                    .andExpect(status().isOk());
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 테스트")
+    public class FailureCases {
+
+        @Test
+        @DisplayName("로그인하지 않은 경우 401 Unauthorized 응답")
+        public void shouldReturn401_whenUserDoesNotSignIn() throws Exception {
+            // given
+            long questionId = 99999L;
+
+            // when & then
+            mockMvc.perform(delete(URI_TEMPLATE + questionId))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("DB에 오답노트가 없는 경우 404 Not Found 응답")
+        public void shouldReturn404_whenEntityDoesNotExistInDB() throws Exception {
+            // given
+            long userId = 1L;
+            long questionId = 99999L;
+
+            doThrow(new EntityNotFoundException("오답노트를 찾을 수 없습니다."))
+                    .when(userWrongNoteDeleteService)
+                    .deleteWrongNote(userId, questionId);
+
+            // when & then
+            mockMvc.perform(delete(URI_TEMPLATE + questionId)
+                            .with(getAuthentication(userId)))
+                    .andExpect(status().isNotFound());
+        }
+    }
+}

--- a/src/test/java/com/upstage/devup/user/wrong/controller/UserWrongNoteQueryControllerTest.java
+++ b/src/test/java/com/upstage/devup/user/wrong/controller/UserWrongNoteQueryControllerTest.java
@@ -1,11 +1,12 @@
-package com.upstage.devup.user.statistics.controller;
+package com.upstage.devup.user.wrong.controller;
 
 import com.upstage.devup.auth.config.AuthenticatedUser;
 import com.upstage.devup.auth.config.SecurityConfig;
 import com.upstage.devup.auth.config.jwt.JwtTokenProvider;
 import com.upstage.devup.user.statistics.dto.WrongNoteSummaryDto;
 import com.upstage.devup.user.statistics.service.UserAnswerStatService;
-import com.upstage.devup.user.statistics.service.UserWrongAnswerReadService;
+import com.upstage.devup.user.wrong.controller.UserWrongNoteQueryController;
+import com.upstage.devup.user.wrong.service.UserWrongAnswerQueryService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,9 +33,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
-@WebMvcTest(UserStatController.class)
+@WebMvcTest(UserWrongNoteQueryController.class)
 @Import(SecurityConfig.class)
-class UserStatControllerTest {
+class UserWrongNoteQueryControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -43,7 +44,7 @@ class UserStatControllerTest {
     private UserAnswerStatService userAnswerStatService;
 
     @MockitoBean
-    private UserWrongAnswerReadService userWrongAnswerReadService;
+    private UserWrongAnswerQueryService userWrongAnswerQueryService;
 
     @MockitoBean
     private JwtTokenProvider jwtTokenProvider;
@@ -70,7 +71,7 @@ class UserStatControllerTest {
         Pageable pageable = PageRequest.of(pageNumber, pageSize);
         Page<WrongNoteSummaryDto> mockPage = new PageImpl<>(items, pageable, items.size());
 
-        when(userWrongAnswerReadService.getWrongNoteSummaries(eq(userId), eq(pageNumber)))
+        when(userWrongAnswerQueryService.getWrongNoteSummaries(eq(userId), eq(pageNumber)))
                 .thenReturn(mockPage);
 
         // when & then

--- a/src/test/java/com/upstage/devup/user/wrong/service/UserWrongAnswerQueryServiceTest.java
+++ b/src/test/java/com/upstage/devup/user/wrong/service/UserWrongAnswerQueryServiceTest.java
@@ -1,4 +1,4 @@
-package com.upstage.devup.user.statistics.service;
+package com.upstage.devup.user.wrong.service;
 
 import com.upstage.devup.global.exception.EntityNotFoundException;
 import com.upstage.devup.user.statistics.dto.WrongNoteSummaryDto;
@@ -13,10 +13,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
-class UserWrongAnswerReadServiceTest {
+class UserWrongAnswerQueryServiceTest {
 
     @Autowired
-    private UserWrongAnswerReadService userWrongAnswerReadService;
+    private UserWrongAnswerQueryService userWrongAnswerQueryService;
 
     @Transactional
     @Test
@@ -27,7 +27,7 @@ class UserWrongAnswerReadServiceTest {
         Integer pageNumber = 0;
 
         // when
-        Page<WrongNoteSummaryDto> results = userWrongAnswerReadService.getWrongNoteSummaries(userId, pageNumber);
+        Page<WrongNoteSummaryDto> results = userWrongAnswerQueryService.getWrongNoteSummaries(userId, pageNumber);
 
         // then
         assertThat(results).isNotEmpty();
@@ -47,7 +47,7 @@ class UserWrongAnswerReadServiceTest {
         // when & then
         EntityNotFoundException exception = assertThrows(
                 EntityNotFoundException.class,
-                () -> userWrongAnswerReadService.getWrongNoteSummaries(userId, pageNumber)
+                () -> userWrongAnswerQueryService.getWrongNoteSummaries(userId, pageNumber)
         );
 
         assertThat(exception.getMessage()).isEqualTo(errorMessage);
@@ -61,7 +61,7 @@ class UserWrongAnswerReadServiceTest {
         Integer pageNumber = 0;
 
         // when
-        Page<WrongNoteSummaryDto> results = userWrongAnswerReadService.getWrongNoteSummaries(userId, pageNumber);
+        Page<WrongNoteSummaryDto> results = userWrongAnswerQueryService.getWrongNoteSummaries(userId, pageNumber);
 
         // then
         assertThat(results).isEmpty();
@@ -79,7 +79,7 @@ class UserWrongAnswerReadServiceTest {
         // when & then
         IllegalArgumentException exception = assertThrows(
                 IllegalArgumentException.class,
-                () -> userWrongAnswerReadService.getWrongNoteSummaries(userId, pageNumber)
+                () -> userWrongAnswerQueryService.getWrongNoteSummaries(userId, pageNumber)
         );
 
         assertThat(exception.getMessage()).isEqualTo(errorMessage);
@@ -93,7 +93,7 @@ class UserWrongAnswerReadServiceTest {
         Integer pageNumber = 100_000_000;
 
         // when
-        Page<WrongNoteSummaryDto> results = userWrongAnswerReadService.getWrongNoteSummaries(userId, pageNumber);
+        Page<WrongNoteSummaryDto> results = userWrongAnswerQueryService.getWrongNoteSummaries(userId, pageNumber);
 
         // then
         assertThat(results).isEmpty();
@@ -112,7 +112,7 @@ class UserWrongAnswerReadServiceTest {
         // when & then
         IllegalArgumentException exception = assertThrows(
                 IllegalArgumentException.class,
-                () -> userWrongAnswerReadService.getWrongNoteSummaries(userId, pageNumber)
+                () -> userWrongAnswerQueryService.getWrongNoteSummaries(userId, pageNumber)
         );
 
         assertThat(exception.getMessage()).isEqualTo(errorMessage);

--- a/src/test/java/com/upstage/devup/user/wrong/service/UserWrongNoteDeleteServiceTest.java
+++ b/src/test/java/com/upstage/devup/user/wrong/service/UserWrongNoteDeleteServiceTest.java
@@ -1,0 +1,116 @@
+package com.upstage.devup.user.wrong.service;
+
+import com.upstage.devup.auth.respository.UserAuthRepository;
+import com.upstage.devup.global.entity.*;
+import com.upstage.devup.global.exception.EntityNotFoundException;
+import com.upstage.devup.question.repository.QuestionRepository;
+import com.upstage.devup.user.account.repository.UserAccountRepository;
+import com.upstage.devup.user.wrong.repository.UserWrongNoteRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Nested
+@Transactional
+@SpringBootTest
+class UserWrongNoteDeleteServiceTest {
+
+    @Autowired
+    private UserWrongNoteDeleteService userWrongNoteDeleteService;
+
+    @Autowired
+    private UserWrongNoteRepository userWrongNoteRepository;
+
+    @Autowired
+    private UserAccountRepository userAccountRepository;
+
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    private long userId;
+    private long questionId;
+
+    @BeforeEach
+    public void beforeEach() {
+        User user = userAccountRepository.save(User.builder()
+                .loginId("user1234")
+                .password("pass1234")
+                .nickname("nickname1234")
+                .email("user1234@gmail.com")
+                .createdAt(LocalDateTime.now())
+                .build());
+
+        Question question = questionRepository.save(Question.builder()
+                .title("제목 1")
+                .questionText("질문 내용")
+                .category(Category.builder().id(1L).build())
+                .level(Level.builder().id(2L).build())
+                .createdAt(LocalDateTime.now())
+                .build());
+
+        UserWrongAnswer userWrongAnswer = UserWrongAnswer.builder()
+                .user(user)
+                .question(question)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        userWrongNoteRepository.save(userWrongAnswer);
+
+        this.userId = user.getId();
+        this.questionId = question.getId();
+    }
+
+    @Nested
+    @DisplayName("성공 케이스")
+    public class SuccessCases {
+
+        @Test
+        @DisplayName("유효한 사용자 ID, 질문 ID를 사용한 경우")
+        public void shouldDeleteWrongNote_whenExistsInDB() {
+            // given
+
+            // when
+            userWrongNoteDeleteService.deleteWrongNote(userId, questionId);
+
+            // then
+            assertFalse(userWrongNoteRepository.existsByUserIdAndQuestionId(userId, questionId));
+        }
+
+    }
+
+    @Nested
+    @DisplayName("실패 케이스")
+    public class FailureCase {
+
+        @ParameterizedTest
+        @CsvSource({
+                "0, 0",
+                "-1, 2",
+                "1, -2"
+        })
+        @DisplayName("DB에 없는 오답노트를 삭제하려는 경우 EntityNotFoundException 예외 발생")
+        public void shouldThrowEntityNotFoundException_whenWrongNoteDoesNotExistInDB(long userId, long questionId) {
+            // given
+
+            // when & then  
+            EntityNotFoundException exception = assertThrows(
+                    EntityNotFoundException.class,
+                    () -> userWrongNoteDeleteService.deleteWrongNote(userId, questionId)
+            );
+
+            assertThat(exception.getMessage()).isEqualTo("오답노트를 찾을 수 없습니다.");
+        }
+    }
+}


### PR DESCRIPTION
## 작업 내용

### 오답노트 화면에 [삭제] 버튼 추가
- `mypage.js` 내 오답노트와 관련된 기능들을 `mypage-wrong-note.js`로 이동
- [삭제] 버튼 hover 시 커서가 바뀌도록 수정

### 오답노트 삭제 기능 구현
- 오답노트 삭제용 API 구현(`/api/wrong/{questionId}`)
- `controller`, `service` 관련 테스트 코드 작성 및 통과 확인


## 참고 사항
- `user/statistics` 내 오답노트 관련 클래스들을 `user/wrong`으로 이동