### PR TITLE
feat: 회원가입용 API 제작 및 화면에 연결

### DIFF
--- a/src/main/java/com/upstage/devup/auth/config/SecurityConfig.java
+++ b/src/main/java/com/upstage/devup/auth/config/SecurityConfig.java
@@ -30,7 +30,8 @@ public class SecurityConfig {
     public static final String[] PUBLIC_APIS = {
             "/api/questions/search",
             "/api/answers/**",
-            "/api/auth/signin"
+            "/api/auth/signup",
+            "/api/auth/signin",
     };
 
     @Value("${security.csrf-enabled:true}")

--- a/src/main/java/com/upstage/devup/auth/controller/SignUpController.java
+++ b/src/main/java/com/upstage/devup/auth/controller/SignUpController.java
@@ -1,0 +1,26 @@
+package com.upstage.devup.auth.controller;
+
+import com.upstage.devup.auth.dto.SignUpRequestDto;
+import com.upstage.devup.auth.dto.SignUpResponseDto;
+import com.upstage.devup.auth.service.UserAuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth/signup")
+@RequiredArgsConstructor
+public class SignUpController {
+
+    private final UserAuthService userAuthService;
+
+    @PostMapping
+    public ResponseEntity<SignUpResponseDto> signUp(@RequestBody @Valid SignUpRequestDto request) {
+        SignUpResponseDto result = userAuthService.signUp(request);
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/com/upstage/devup/auth/dto/SignUpRequestDto.java
+++ b/src/main/java/com/upstage/devup/auth/dto/SignUpRequestDto.java
@@ -9,6 +9,7 @@ import lombok.*;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode
 public class SignUpRequestDto {
 
     @NotBlank(message = "아이디는 필수 항목입니다.")
@@ -20,6 +21,7 @@ public class SignUpRequestDto {
     @NotBlank(message = "닉네임은 필수 항목입니다.")
     private String nickname;
 
+    @NotBlank(message = "이메일 형식이 아닙니다.")
     @Email(message = "이메일 형식이 아닙니다.")
     private String email;
 

--- a/src/main/java/com/upstage/devup/auth/service/UserAuthService.java
+++ b/src/main/java/com/upstage/devup/auth/service/UserAuthService.java
@@ -71,21 +71,17 @@ public class UserAuthService {
      * @throws ValueAlreadyInUseException 중복 검사 시 이미 사용 중인 값일 때 발생
      */
     public SignUpResponseDto signUp(SignUpRequestDto request) {
-        if (request == null) {
-            throw new IllegalArgumentException("유효하지 않는 요청입니다.");
-        }
-
         // 중복 검사
         if (isLoginIdInUse(request.getLoginId())) {
-            throw new ValueAlreadyInUseException("이미 사용 중입니다.");
+            throw new ValueAlreadyInUseException("이미 사용 중인 아이디입니다.");
         }
 
         if (isNicknameInUse(request.getNickname())) {
-            throw new ValueAlreadyInUseException("이미 사용 중입니다.");
+            throw new ValueAlreadyInUseException("이미 사용 중인 닉네임입니다.");
         }
 
         if (isEmailInUse(request.getEmail())) {
-            throw new ValueAlreadyInUseException("이미 사용 중입니다.");
+            throw new ValueAlreadyInUseException("이미 사용 중인 이메일입니다.");
         }
 
         User savedEntity = userAuthRepository.save(userMapper.toEntity(request));

--- a/src/main/java/com/upstage/devup/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/upstage/devup/global/handler/GlobalExceptionHandler.java
@@ -5,8 +5,10 @@ import com.upstage.devup.global.exception.UnauthenticatedException;
 import com.upstage.devup.global.domain.dto.ErrorResponse;
 import com.upstage.devup.global.exception.EntityNotFoundException;
 import com.upstage.devup.global.exception.ValueAlreadyInUseException;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -46,5 +48,19 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(new ErrorResponse("BAD_REQUEST", e.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleUnauthenticated(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .findFirst()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .orElse("잘못된 입력입니다.");
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse("VALIDATION_FAILED", message));
     }
 }

--- a/src/main/java/com/upstage/devup/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/upstage/devup/global/handler/GlobalExceptionHandler.java
@@ -30,7 +30,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ValueAlreadyInUseException.class)
     public ResponseEntity<ErrorResponse> handleValueAlreadyInUse(ValueAlreadyInUseException e) {
         return ResponseEntity
-                .status(HttpStatus.NOT_FOUND)
+                .status(HttpStatus.CONFLICT)
                 .body(new ErrorResponse("VALUE_ALREADY_IN_USE", e.getMessage()));
     }
 

--- a/src/main/resources/static/js/auth/signup.js
+++ b/src/main/resources/static/js/auth/signup.js
@@ -1,3 +1,51 @@
+const form = document.getElementById("signup-form");
+form.addEventListener('submit', handleSignUpSubmit);
+
+const submitBtn = document.getElementById("submit-btn");
+
+async function handleSignUpSubmit(event) {
+    event.preventDefault();
+
+    submitBtn.disabled = true;
+
+    try {
+        if (!validateSignup()) {
+            return;
+        }
+
+        const response = await fetch('/api/auth/signup', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                "loginId": form.loginId.value,
+                "password": form.password.value,
+                "nickname": form.nickname.value,
+                "email": form.email.value
+            })
+        });
+
+        if (response.status !== 200) {
+            const data = await response.json();
+            alert(data.message);
+            return;
+        }
+
+        if (!response.ok) {
+            alert("회원가입에 실패했습니다.");
+        }
+
+        alert('회원가입 되었습니다.')
+        window.location.href = '/auth/signin';
+    } catch (err) {
+        alert(err)
+    } finally {
+        submitBtn.disabled = false;
+    }
+
+}
+
 function validateSignup() {
     if (!validateLoginId()) return false;
     if (!validatePassword()) return false;
@@ -27,8 +75,6 @@ function validateLoginId() {
 function validatePassword() {
     const password = document.getElementById('password').value;
     const passwordConfirm = document.getElementById('password_confirm').value;
-
-    console.log(password);
 
     if (!password) {
         alert("비밀번호를 입력해주세요.");

--- a/src/main/resources/static/js/auth/signup.js
+++ b/src/main/resources/static/js/auth/signup.js
@@ -28,6 +28,8 @@ function validatePassword() {
     const password = document.getElementById('password').value;
     const passwordConfirm = document.getElementById('password_confirm').value;
 
+    console.log(password);
+
     if (!password) {
         alert("비밀번호를 입력해주세요.");
         return false;
@@ -80,6 +82,6 @@ function isStrongPassword(pw) {
         /[A-Z]/.test(pw) &&
         /[a-z]/.test(pw) &&
         /\d/.test(pw) &&
-        /[!@#$%^&*(),.?":{}|<>]/.test(pw)
+        /[!@#$^&*()_+=-?]/.test(pw)
     );
 }

--- a/src/main/resources/templates/auth/signup.html
+++ b/src/main/resources/templates/auth/signup.html
@@ -26,7 +26,7 @@
     </div>
     <div class="container">
         <h2>회원가입</h2>
-        <form action="#" method="post" onsubmit="return validateSignup();">
+        <form id="signup-form" action="#" method="post">
             <div class="form-group">
                 <label for="login_id">아이디</label>
                 <input type="text" id="login_id" name="loginId" placeholder="아이디 입력" required/>
@@ -53,7 +53,7 @@
             </div>
 
             <div class="form-actions">
-                <button type="submit">가입하기</button>
+                <button id="submit-btn" type="submit">가입하기</button>
             </div>
         </form>
     </div>

--- a/src/main/resources/templates/user/mypage/mypage.th.xml
+++ b/src/main/resources/templates/user/mypage/mypage.th.xml
@@ -10,7 +10,11 @@
                 <attr sel="strong" th:text="${quizStat.totalCount}"/>
             </attr>
             <attr sel=".card[1]">
-                <attr sel="strong" th:text="${(quizStat.correctCount / quizStat.totalCount * 100) + '%'}"/>
+                <attr sel="strong"
+                      th:text="${quizStat.totalCount == 0
+                      ? '0%'
+                      : #numbers.formatDecimal(quizStat.correctCount / quizStat.totalCount * 100, 0, 0) + '%'}"
+                />
             </attr>
             <attr sel=".card[2]">
                 <attr sel=".gauge-bar" th:remove="all-but-first">

--- a/src/test/java/com/upstage/devup/auth/controller/SignUpControllerTest.java
+++ b/src/test/java/com/upstage/devup/auth/controller/SignUpControllerTest.java
@@ -1,0 +1,266 @@
+package com.upstage.devup.auth.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.upstage.devup.auth.config.SecurityConfig;
+import com.upstage.devup.auth.config.jwt.JwtTokenProvider;
+import com.upstage.devup.auth.dto.SignUpRequestDto;
+import com.upstage.devup.auth.dto.SignUpResponseDto;
+import com.upstage.devup.auth.service.UserAuthService;
+import com.upstage.devup.global.exception.ValueAlreadyInUseException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(SignUpController.class)
+@Import(SecurityConfig.class)
+class SignUpControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private UserAuthService userAuthService;
+
+    private static final String URI_TEMPLATE = "/api/auth/signup";
+    private static final String VALIDATION_FAILED_CODE = "VALIDATION_FAILED";
+    private static final String EMPTY_LOGIN_ID_ERR_MSG = "아이디는 필수 항목입니다.";
+    private static final String EMPTY_PASSWORD_ERR_MSG = "비밀번호는 필수 항목입니다.";
+    private static final String EMPTY_NICKNAME_ERR_MSG = "닉네임은 필수 항목입니다.";
+    private static final String EMAIL_FORMAT_ERR_MSG = "이메일 형식이 아닙니다.";
+
+    private static final String VALUE_ALREADY_IN_USE = "VALUE_ALREADY_IN_USE";
+    private static final String USED_LOGIN_ID_ERR_MSG = "이미 사용 중인 아이디입니다.";
+    private static final String USED_NICKNAME_ERR_MSG = "이미 사용 중인 닉네임입니다.";
+    private static final String USED_EMAIL_ERR_MSG = "이미 사용 중인 이메일입니다.";
+
+    private String loginId = "qwerty";
+    private String password = "1111";
+    private String nickname = "nick";
+    private String email = "test@devup.com";
+
+
+    @BeforeEach
+    void setUp() {
+        loginId = "qwerty";
+        password = "1111";
+        nickname = "nick";
+        email = "test@devup.com";
+    }
+
+    private SignUpRequestDto createSignUpRequestDto(String loginId, String password, String nickname, String email) {
+        return SignUpRequestDto.builder()
+                .loginId(loginId)
+                .password(password)
+                .nickname(nickname)
+                .email(email)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("회원가입 성공 케이스")
+    public class SuccessCases {
+
+        @Test
+        @DisplayName("유효한 회원가입 데이터를 사용한 경우")
+        public void shouldReturn200_whenValidRequest() throws Exception {
+            // given
+            SignUpRequestDto request = createSignUpRequestDto(loginId, password, nickname, email);
+            SignUpResponseDto mockResponse = SignUpResponseDto.builder()
+                    .id(1L)
+                    .loginId(loginId)
+                    .nickname(nickname)
+                    .email(email)
+                    .build();
+
+            when(userAuthService.signUp(eq(request)))
+                    .thenReturn(mockResponse);
+
+            // when & then
+            mockMvc.perform(post(URI_TEMPLATE)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+                    .andExpect(jsonPath("$.loginId").value(request.getLoginId()))
+                    .andExpect(jsonPath("$.nickname").value(request.getNickname()))
+                    .andExpect(jsonPath("$.email").value(request.getEmail()));
+        }
+    }
+
+    @Nested
+    @DisplayName("회원가입 실패 케이스 - 유효하지 않은 회원가입 데이터를 사용한 경우")
+    public class InvalidInputCases {
+
+        @DisplayName("아이디 누락 - 400 Bad Request 응답")
+        @ParameterizedTest
+        @NullAndEmptySource
+        public void shouldReturn400_whenLoginIdIsBlank(String blank) throws Exception {
+            // given
+            SignUpRequestDto request = createSignUpRequestDto(blank, password, nickname, email);
+
+            // when & then
+            mockMvc.perform(post(URI_TEMPLATE)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.code").value(VALIDATION_FAILED_CODE))
+                    .andExpect(jsonPath("$.message").value(EMPTY_LOGIN_ID_ERR_MSG));
+        }
+
+        @DisplayName("비밀번호 누락 - 400 Bad Request 응답")
+        @ParameterizedTest
+        @NullAndEmptySource
+        public void shouldReturn400_whenPasswordIsBlank(String blank) throws Exception {
+            // given
+            SignUpRequestDto request = createSignUpRequestDto(loginId, blank, nickname, email);
+
+            // when & then
+            mockMvc.perform(post(URI_TEMPLATE)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.code").value(VALIDATION_FAILED_CODE))
+                    .andExpect(jsonPath("$.message").value(EMPTY_PASSWORD_ERR_MSG));
+        }
+
+        @DisplayName("닉네임 누락 - 400 Bad Request 응답")
+        @ParameterizedTest
+        @NullAndEmptySource
+        public void shouldReturn400_whenNicknameIsBlank(String blank) throws Exception {
+            // given
+            SignUpRequestDto request = createSignUpRequestDto(loginId, password, blank, email);
+
+            // when & then
+            mockMvc.perform(post(URI_TEMPLATE)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.code").value(VALIDATION_FAILED_CODE))
+                    .andExpect(jsonPath("$.message").value(EMPTY_NICKNAME_ERR_MSG));
+        }
+
+        @DisplayName("이메일 누락 - 400 Bad Request 응답")
+        @ParameterizedTest
+        @NullAndEmptySource
+        public void shouldReturn400_whenEmailIsBlank(String blank) throws Exception {
+            // given
+            SignUpRequestDto request = createSignUpRequestDto(loginId, password, nickname, blank);
+
+            // when & then
+            mockMvc.perform(post(URI_TEMPLATE)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.code").value(VALIDATION_FAILED_CODE))
+                    .andExpect(jsonPath("$.message").value(EMAIL_FORMAT_ERR_MSG));
+        }
+
+        @DisplayName("이메일 형식이 아닌 경우 400 Bad Request 응답")
+        @ParameterizedTest
+        @CsvSource({
+                "@",
+                "test@",
+                "test@dev."
+        })
+        public void shouldReturn400_whenEmailIsNotWellFormed(String localEmail) throws Exception {
+            // given
+            SignUpRequestDto request = createSignUpRequestDto(loginId, password, nickname, localEmail);
+
+            // when & then
+            mockMvc.perform(post(URI_TEMPLATE)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.code").value(VALIDATION_FAILED_CODE))
+                    .andExpect(jsonPath("$.message").value(EMAIL_FORMAT_ERR_MSG));
+        }
+    }
+
+    @Nested
+    @DisplayName("회원가입 실패 케이스 - 실제 사용중인 값을 사용한 경우")
+    public class FailureCases_UsingDuplicatedValue {
+
+        @Test
+        @DisplayName("중복된 아이디 사용 - 409 Conflict 응답")
+        public void shouldReturn409_whenLoginIdIsAlreadyUsed() throws Exception {
+            // given
+            SignUpRequestDto request = createSignUpRequestDto(loginId, password, nickname, email);
+
+            when(userAuthService.signUp(eq(request)))
+                    .thenThrow(new ValueAlreadyInUseException(USED_LOGIN_ID_ERR_MSG));
+
+            // when & then
+            mockMvc.perform(post(URI_TEMPLATE)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isConflict())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.code").value(VALUE_ALREADY_IN_USE))
+                    .andExpect(jsonPath("$.message").value(USED_LOGIN_ID_ERR_MSG));
+        }
+
+        @Test
+        @DisplayName("중복된 닉네임 사용 - 409 Conflict 응답")
+        public void shouldReturn409_whenNicknameIsAlreadyUsed() throws Exception {
+            // given
+            SignUpRequestDto request = createSignUpRequestDto(loginId, password, nickname, email);
+
+            when(userAuthService.signUp(eq(request)))
+                    .thenThrow(new ValueAlreadyInUseException(USED_NICKNAME_ERR_MSG));
+
+            // when & then
+            mockMvc.perform(post(URI_TEMPLATE)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isConflict())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.code").value(VALUE_ALREADY_IN_USE))
+                    .andExpect(jsonPath("$.message").value(USED_NICKNAME_ERR_MSG));
+        }
+
+        @Test
+        @DisplayName("중복된 이메일 사용 - 409 Conflict 응답")
+        public void shouldReturn409_whenEmailIsAlreadyUsed() throws Exception {
+            // given
+            SignUpRequestDto request = createSignUpRequestDto(loginId, password, nickname, email);
+
+            when(userAuthService.signUp(eq(request)))
+                    .thenThrow(new ValueAlreadyInUseException(USED_EMAIL_ERR_MSG));
+
+            // when & then
+            mockMvc.perform(post(URI_TEMPLATE)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isConflict())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.code").value(VALUE_ALREADY_IN_USE))
+                    .andExpect(jsonPath("$.message").value(USED_EMAIL_ERR_MSG));
+        }
+    }
+}


### PR DESCRIPTION
## 작업 내용

### 회원가입용 API 제작(`/api/auth/signup`)
- `SecurityConfig`에 예외 경로로 등
- `GlobalExceptionHandler`에 `MethodArgumentNotValidException` 예외 관련 핸들러 등록
- 테스트 코드 작성 및 통과 확인

### 회원가입 로직 수정 및 테스트 코드 수정
- 특수문자 조회 시 큰따옴표 때문에 가입 진행이 안되는 문제 해결
  - 특정 특수문자만 사용 가능하도록 수정
- 중복검사 시 발생하는 에러 메시지 수정
- `@Nested`를 사용해 테스트 케이스 분류
- `ValueAlreadyInUseException` 예외 발생 시 `409(Conflict)`를 반환하도록 수정

### 회원가입 화면 수정
- [가입하기] 버튼에 회원가입 요청 기능 연결