### PR TITLE
fix: 테스트 실행 시 실패하는 테스트 코드 수정

### DIFF
--- a/src/test/java/com/upstage/devup/user/answer/service/UserAnswerSaveServiceTest.java
+++ b/src/test/java/com/upstage/devup/user/answer/service/UserAnswerSaveServiceTest.java
@@ -57,24 +57,6 @@ class UserAnswerSaveServiceTest {
     }
 
     @Test
-    @DisplayName("사용자 답안 저장 실패 - 사용자 ID가 null인 경우 EntityNotFoundException 발생")
-    public void shouldThrowEntityException_whenUserIdIsNull() {
-        // given
-        Long userId = null;
-        String errorMessage = "사용자 정보를 찾을 수 없습니다.";
-
-        UserAnswerSaveRequest request = UserAnswerSaveRequest.builder().build();
-
-        // when
-        EntityNotFoundException exception = assertThrows(
-                EntityNotFoundException.class,
-                () -> userAnswerSaveService.saveUserAnswer(userId, request)
-        );
-
-        assertThat(exception.getMessage()).isEqualTo(errorMessage);
-    }
-
-    @Test
     @DisplayName("사용자 답안 저장 실패 - 유효하지 않은 사용자 ID를 경우 EntityNotFoundException 발생")
     public void shouldThrowEntityException_whenUserIdIsUnavailable() {
         // given


### PR DESCRIPTION
## 작업 내용

### 사용자 ID가 null일 때 답안 저장 테스트 실패하는 문제 해결
- UserAnswerSaveService의 saveUserAnswer 메서드는 사용자 ID를 long으로 받음
- 테스트에서는 사용자 ID를 null로 사용하고 있었음
- 사용자 ID가 null인 경우를 테스트하는 코드 삭제
- 전체 테스트 진행 후 모든 테스트가 통과하는 것을 확인