### PR TITLE
chore: build.gradle에 dotenv 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6:3.1.2.RELEASE'
+	implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 
 	// JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'


### PR DESCRIPTION
## 작업 내용
### dotenv 의존성 추가
- dotenv는 .env 파일에 작성한 환경 변수 값을 사용하기 위한 라이브러리임