### PR TITLE
fix: 풀이 이력, 오답 노트 목록 화면 CSS 수정

### DIFF
--- a/src/main/resources/static/css/user/mypage/mypage.css
+++ b/src/main/resources/static/css/user/mypage/mypage.css
@@ -139,6 +139,11 @@ tr:hover {
     background-color: #f9f9f9;
 }
 
+td a {
+    text-decoration: none;
+    color: inherit;
+}
+
 .tag.correct {
     background-color: #27ae60;
     color: white;


### PR DESCRIPTION
## 작업 내용
### mypage.css 수정
- 표 안의 <a> 태그에 `text-decoration: none`를 추가해 하단 선 제거
- `color: inherit`을 사용해 글자색 지정