### PR TITLE
fix: hikari cp pool, tomcat의 스레드 수 수정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -71,10 +71,18 @@ spring:
     driver-class-name: org.mariadb.jdbc.Driver
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
+    hikari:
+      maximum-pool-size: 101
   jpa:
     hibernate:
       ddl-auto: validate
     show-sql: false
+
+server:
+  tomcat:
+    threads:
+      max: 100
+  port: 8080
 
 security:
   csrf-enabled: false


### PR DESCRIPTION
## 작업 내용
- `hikari cp pool` 최대 스레드 수 변경(10 -> 101)
- `tomcat` 스레드 수 변경(200 -> 100)

## 문제 원인
- EC2에서 서버 실행 시 `thread starvation or clock leap detected` 발생
- CPU 사용량이 100%를 찍고 EC2 인스턴스가 멈추는 현상 발생

## 참고 사항
- `hikari cp pool`, `tomcat`의 적정 스레드 수를 구하는 방식이 있음
- 내용 파악 후 정확한 스레드 수로 변경할 예정