### PR TITLE
ci: CI/CD 설정 및 빌드 설정 변경

### DIFF
--- a/.github/workflow/deploy.yml
+++ b/.github/workflow/deploy.yml
@@ -8,6 +8,11 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
 
+    env:
+      DB_URL: ${ { secrets.DB_URL } }
+      DB_USERNAME: ${ { secrets.DB_USERNAME } }
+      DB_PASSWORD: ${ { secrets.DB_PASSWORD } }
+
     steps:
       # CI
       - name: Checkout code

--- a/.github/workflow/deploy.yml
+++ b/.github/workflow/deploy.yml
@@ -1,0 +1,46 @@
+name: CI/CD
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      # CI
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: '17'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        uses: ./gradlew clean build
+
+      # CD
+      - name: Copy JAR to EC2
+        uses: appleboy/scp-action@v0.1.4
+        with:
+          host: ${ { secrets.EC2_HOST } }
+          username: ${ { secrets.EC2_USER } }
+          key: ${ { secrets.EC2_KEY } }
+          source: build/libs/devup.jar
+          target: /home/ec2-user/app/
+
+      - name: Restart service
+        uses: appleboy/ssh-action@v0.1.7
+        with:
+          host: ${ { secrets.EC2_HOST } }
+          username: ${ { secrets.EC2_USER } }
+          key: ${ { secrets.EC2_KEY } }
+          script: |
+            sudo systemctl daemon-reload
+            sudo systemctl restart devup

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,10 @@ configurations {
 	}
 }
 
+bootJar {
+	archiveFileName = 'devup.jar'
+}
+
 repositories {
 	mavenCentral()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,10 @@ bootJar {
 	archiveFileName = 'devup.jar'
 }
 
+jar {
+	enabled = false
+}
+
 repositories {
 	mavenCentral()
 }


### PR DESCRIPTION
## 작업 내용

### GitHub Actions 배포 워크플로우 추가
- `deploy.yml` 파일 생성 및 설정
- GitHub Secrets 기반 테스트용 환경 변수 연결

### 빌드 설정  변경
- 빌드 파일명을 `devup.jar`로 변경
- 빌드 시 `plain.jar` 파일이 생성되지 않도록 `jar` task 비활성화

## 참고 사항
- PR 생성 전 `develop` 브랜치를 작업 브랜치에 merge 완료