### PR TITLE
ci: CI 테스트용 profile 및 빌드 설정 개선

### DIFF
--- a/.github/workflow/deploy.yml
+++ b/.github/workflow/deploy.yml
@@ -9,9 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      DB_URL: ${ { secrets.DB_URL } }
-      DB_USERNAME: ${ { secrets.DB_USERNAME } }
-      DB_PASSWORD: ${ { secrets.DB_PASSWORD } }
+      SPRING_PROFILES_ACTIVE: ci
 
     steps:
       # CI
@@ -28,7 +26,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build with Gradle
-        uses: ./gradlew clean build
+        run: ./gradlew clean build
 
       # CD
       - name: Copy JAR to EC2

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -86,3 +86,26 @@ server:
 
 security:
   csrf-enabled: false
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile: ci
+  datasource:
+    url: jdbc:h2:mem:devup;MODE=MySQL;
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQL8Dialect
+  sql:
+    init:
+      mode: always


### PR DESCRIPTION
## 작업 내용

### CI 테스트용 profile 설정 추가
- CI 환경에서 H2를 사용하도록 설정

### CI 빌드 설정 변경
- 불필요한 환경 변수 제거(`DB_URL`, `DB_USERNAME`, `DB_PASSWORD`)
- `SPRING_PROFILES_ACTIVE: ci` 추가
- build 단계 `run` 구문 오타 수정