### PR TITLE
fix: GitHub Actions 환경 변수 띄어쓰기 오타 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,18 +29,18 @@ jobs:
       - name: Copy JAR to EC2
         uses: appleboy/scp-action@v0.1.4
         with:
-          host: ${ { secrets.EC2_HOST } }
-          username: ${ { secrets.EC2_USER } }
-          key: ${ { secrets.EC2_KEY } }
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_KEY }}
           source: build/libs/devup.jar
           target: /home/ec2-user/app/
 
       - name: Restart service
         uses: appleboy/ssh-action@v0.1.7
         with:
-          host: ${ { secrets.EC2_HOST } }
-          username: ${ { secrets.EC2_USER } }
-          key: ${ { secrets.EC2_KEY } }
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_KEY }}
           script: |
             sudo systemctl daemon-reload
             sudo systemctl restart devup


### PR DESCRIPTION
## 작업 내용

### GitHub Actions 환경 변수 띄어쓰기 오타 수정
- `${ { secrets.EC2_HOST } }`에서 중괄호 사이의 띄어쓰기 삭제
- `${{ secrets.EC2_HOST }}`로 써야 정상적으로 인식됨