### PR TITLE
refactor: OIDC 기반 배포 방식 적용 (deploy.yml 수정)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,21 +26,26 @@ jobs:
         run: ./gradlew clean build -x test
 
       # CD
-      - name: Copy JAR to EC2
-        uses: appleboy/scp-action@v0.1.4
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v2
         with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_KEY }}
-          source: build/libs/devup.jar
-          target: /home/ec2-user/app/
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-session-name: github-actions
+          aws-region: ${{ secrets.AWS_REGION }}
 
-      - name: Restart service
-        uses: appleboy/ssh-action@v0.1.7
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_KEY }}
-          script: |
-            sudo systemctl daemon-reload
-            sudo systemctl restart devup
+      - name: Upload JAR to S3
+        run: |
+          aws s3 cp build/libs/devup.jar ${{ secrets.S3_BUCKET_PATH }}
+
+      - name: Run SSM command on EC2
+        run: |
+          aws ssm send-command \
+            --document-name "AWS-RunShellScript" \
+            --instance-ids ${{ secrets.EC2_INSTANCE_ID }} \
+            --region ${{ secrets.AWS_REGION }} \
+            --comment "Deploy App" \
+            --parameters 'commands=[
+                "aws s3 cp ${{ secrets.S3_BUCKET_PATH }} ${{ secrets.DEPLOY_PATH }}",
+                "sudo systemctl restart ${{ secrets.SERVICE_NAME }}"
+              ]' \
+            --output text


### PR DESCRIPTION
## 작업 내용
- 기존 SSH 방식의 배포를 제거하고, OIDC 기반 GitHub Actions 자동 배포 방식으로 전환
- GitHub Actions에서 OIDC로 인증하여 AWS CLI 실행
- 빌드된 `.jar` 파일을 S3에 업로드하고, SSM을 통해 EC2에 배포 및 실행
- AWS 리소스 접근은 GitHub Secrets를 통해 안전하게 관리
