### PR TITLE
fix: 누락된 GitHub Actions 워크플로우의 권한 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 작업 내용
- `deploy.yml`에 누락된 GitHub Actions 워크플로우의 권한 추가

## 권한 설명
|키|설명|
|---|---|
|`id-token: write`|- OIDC 토큰을 발급받기 위한 필수 권한<br>- AWS 인증 시 필요<br>- `aws-actions/configure-aws-credentials`에서 사용|
|`contents: read`|- GitHub 저장소 내용을 읽기 위한 권한<br>- `actions/checkout`에서 코드를 내려받을 때 필요|