### PR TITLE
feat: 북마크 기능 추가

### DIFF
--- a/docs/erd/v1.0.3.erd
+++ b/docs/erd/v1.0.3.erd
@@ -124,15 +124,15 @@
           "9thSvk11o4L2mrhR5RjNm"
         ],
         "ui": {
-          "x": 899.3499,
-          "y": 789.4294,
+          "x": 1069.3499,
+          "y": 659.4294,
           "zIndex": 57,
           "widthName": 60,
           "widthComment": 71,
           "color": ""
         },
         "meta": {
-          "updateAt": 1746534093011,
+          "updateAt": 1749213453473,
           "createAt": 1745497332800
         }
       },
@@ -152,15 +152,15 @@
           "eQVTYYo6DkFvrgl8uc08f"
         ],
         "ui": {
-          "x": 232.896,
-          "y": 896.7079,
+          "x": 53.896,
+          "y": 848.7079,
           "zIndex": 67,
           "widthName": 62,
           "widthComment": 71,
           "color": ""
         },
         "meta": {
-          "updateAt": 1747190839674,
+          "updateAt": 1749213410474,
           "createAt": 1745497478333
         }
       },
@@ -177,15 +177,15 @@
           "PZNJcHrv12XoDKy1E94EA"
         ],
         "ui": {
-          "x": 333.3098,
-          "y": 1052.1503,
+          "x": 51.3098,
+          "y": 995.1503,
           "zIndex": 102,
           "widthName": 60,
           "widthComment": 60,
           "color": ""
         },
         "meta": {
-          "updateAt": 1747190799119,
+          "updateAt": 1749213416939,
           "createAt": 1745497833117
         }
       },
@@ -209,15 +209,15 @@
           "zDUaZts6zMEyhxenWUtPu"
         ],
         "ui": {
-          "x": 1342.1923,
-          "y": 319.3357,
+          "x": 1136.1923,
+          "y": 971.3357,
           "zIndex": 110,
           "widthName": 60,
           "widthComment": 60,
           "color": ""
         },
         "meta": {
-          "updateAt": 1747190865740,
+          "updateAt": 1749213481507,
           "createAt": 1745497874393
         }
       },
@@ -243,15 +243,15 @@
           "W9JLIXKYfvwzM7nbcUymM"
         ],
         "ui": {
-          "x": 506.888,
-          "y": 298.4471,
+          "x": 387.888,
+          "y": 454.4471,
           "zIndex": 131,
           "widthName": 80,
           "widthComment": 92,
           "color": ""
         },
         "meta": {
-          "updateAt": 1746534087559,
+          "updateAt": 1749213438941,
           "createAt": 1745498004462
         }
       },
@@ -275,15 +275,15 @@
           "skm1SlUBPVALol5gUJUeT"
         ],
         "ui": {
-          "x": 330.2126,
-          "y": 546.4071,
+          "x": 55.2126,
+          "y": 673.4071,
           "zIndex": 147,
           "widthName": 91,
           "widthComment": 81,
           "color": ""
         },
         "meta": {
-          "updateAt": 1746534101153,
+          "updateAt": 1749213399107,
           "createAt": 1745498264054
         }
       },
@@ -292,26 +292,27 @@
         "name": "bookmarks",
         "comment": "북마크",
         "columnIds": [
-          "GgW95yo8hI83OdCmTVU61",
           "H9QsMBnhPHJx0fL86Anxg",
-          "cyB0VtfkXoegatCzQQIfM"
+          "cyB0VtfkXoegatCzQQIfM",
+          "7bF4olHjFiJSnTgoz1OXG"
         ],
         "seqColumnIds": [
           "VObppcT66U8dAJwRHZdKq",
           "GgW95yo8hI83OdCmTVU61",
           "H9QsMBnhPHJx0fL86Anxg",
-          "cyB0VtfkXoegatCzQQIfM"
+          "cyB0VtfkXoegatCzQQIfM",
+          "7bF4olHjFiJSnTgoz1OXG"
         ],
         "ui": {
-          "x": 21.5602,
-          "y": 724.1082,
+          "x": 829.5602,
+          "y": 62.1082,
           "zIndex": 183,
           "widthName": 64,
           "widthComment": 60,
           "color": ""
         },
         "meta": {
-          "updateAt": 1746534098546,
+          "updateAt": 1749213432240,
           "createAt": 1745498474160
         }
       },
@@ -332,15 +333,15 @@
           "FJv128iZQYa6bUl9XgjCt"
         ],
         "ui": {
-          "x": 1375.8909,
-          "y": 534.1892,
+          "x": 527.8909,
+          "y": 1085.1892,
           "zIndex": 206,
           "widthName": 85,
           "widthComment": 71,
           "color": ""
         },
         "meta": {
-          "updateAt": 1747190841447,
+          "updateAt": 1749213475739,
           "createAt": 1745498558417
         }
       },
@@ -369,15 +370,15 @@
           "c8Bkdi6BJ_wN4BCR-3eif"
         ],
         "ui": {
-          "x": 960.1924,
-          "y": 44.5341,
+          "x": 832.1924,
+          "y": 205.5341,
           "zIndex": 335,
           "widthName": 108,
           "widthComment": 95,
           "color": ""
         },
         "meta": {
-          "updateAt": 1746533992336,
+          "updateAt": 1749213457445,
           "createAt": 1745507027071
         }
       }
@@ -970,16 +971,16 @@
         "comment": "",
         "dataType": "BIGINT",
         "default": "",
-        "options": 8,
+        "options": 10,
         "ui": {
-          "keys": 2,
+          "keys": 3,
           "widthName": 60,
           "widthComment": 60,
           "widthDataType": 60,
           "widthDefault": 60
         },
         "meta": {
-          "updateAt": 1746098924546,
+          "updateAt": 1749213220275,
           "createAt": 1745498495079
         }
       },
@@ -990,16 +991,16 @@
         "comment": "",
         "dataType": "BIGINT",
         "default": "",
-        "options": 8,
+        "options": 10,
         "ui": {
-          "keys": 2,
+          "keys": 3,
           "widthName": 68,
           "widthComment": 60,
           "widthDataType": 60,
           "widthDefault": 60
         },
         "meta": {
-          "updateAt": 1746098925612,
+          "updateAt": 1749213221774,
           "createAt": 1745498508788
         }
       },
@@ -1622,6 +1623,26 @@
           "updateAt": 1747190833888,
           "createAt": 1747190800779
         }
+      },
+      "7bF4olHjFiJSnTgoz1OXG": {
+        "id": "7bF4olHjFiJSnTgoz1OXG",
+        "tableId": "QRtSx4RMjyg8xmvY7GPrI",
+        "name": "created_at",
+        "comment": "",
+        "dataType": "TIMESTAMP",
+        "default": "CURRENT_TIMESTAMP",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 63,
+          "widthComment": 60,
+          "widthDataType": 71,
+          "widthDefault": 133
+        },
+        "meta": {
+          "updateAt": 1749213244408,
+          "createAt": 1749213223434
+        }
       }
     },
     "relationshipEntities": {
@@ -1635,8 +1656,8 @@
           "columnIds": [
             "bYBD1G5Rtzfd5bmHp1PSN"
           ],
-          "x": 745.896,
-          "y": 960.7079,
+          "x": 566.896,
+          "y": 912.7079,
           "direction": 2
         },
         "end": {
@@ -1644,8 +1665,8 @@
           "columnIds": [
             "jxmmoPgOw5fyFw6AqcBCS"
           ],
-          "x": 899.3499,
-          "y": 929.4294,
+          "x": 1069.3499,
+          "y": 771.4293999999999,
           "direction": 1
         },
         "meta": {
@@ -1663,8 +1684,8 @@
           "columnIds": [
             "7-m0nv5D2FbXOnd4f4Bgm"
           ],
-          "x": 774.3098,
-          "y": 1104.1503,
+          "x": 492.3098,
+          "y": 1047.1503,
           "direction": 2
         },
         "end": {
@@ -1672,8 +1693,8 @@
           "columnIds": [
             "7hHdemvf8tf1gBG5k8EXx"
           ],
-          "x": 899.3499,
-          "y": 985.4294,
+          "x": 1069.3499,
+          "y": 816.2293999999998,
           "direction": 1
         },
         "meta": {
@@ -1691,18 +1712,18 @@
           "columnIds": [
             "y7mIA2j_HBZKM9Fe9yR2v"
           ],
-          "x": 1241.8499000000002,
-          "y": 789.4294,
-          "direction": 4
+          "x": 1343.3499,
+          "y": 883.4294,
+          "direction": 8
         },
         "end": {
           "tableId": "PoVTyDcupvCwdz-QrJw7w",
           "columnIds": [
             "LZTT3T0iLrGsGDiWojy6n"
           ],
-          "x": 1342.1923,
-          "y": 407.3357,
-          "direction": 1
+          "x": 1404.6923,
+          "y": 971.3357,
+          "direction": 4
         },
         "meta": {
           "updateAt": 1745497930816,
@@ -1719,7 +1740,7 @@
           "columnIds": [
             "aZV1EX4pI-WE6FSIeloqW"
           ],
-          "x": 495.38536666666664,
+          "x": 449.4687,
           "y": 266.1023,
           "direction": 8
         },
@@ -1728,8 +1749,8 @@
           "columnIds": [
             "_gwHoDh2lO7fUm8OfzcUV"
           ],
-          "x": 506.888,
-          "y": 398.4471,
+          "x": 387.888,
+          "y": 554.4471,
           "direction": 1
         },
         "meta": {
@@ -1747,17 +1768,17 @@
           "columnIds": [
             "y7mIA2j_HBZKM9Fe9yR2v"
           ],
-          "x": 967.8499,
-          "y": 789.4294,
-          "direction": 4
+          "x": 1069.3499,
+          "y": 681.8294,
+          "direction": 1
         },
         "end": {
           "tableId": "LjZoHLvA6UqrBIsKzV7kT",
           "columnIds": [
             "IrobFUndU4WWxGROXjnhj"
           ],
-          "x": 1117.888,
-          "y": 398.4471,
+          "x": 998.8879999999999,
+          "y": 554.4471,
           "direction": 2
         },
         "meta": {
@@ -1775,7 +1796,7 @@
           "columnIds": [
             "aZV1EX4pI-WE6FSIeloqW"
           ],
-          "x": 311.7187,
+          "x": 173.9687,
           "y": 266.1023,
           "direction": 8
         },
@@ -1784,9 +1805,9 @@
           "columnIds": [
             "kwiSsLPW9j-cKxdERkjtP"
           ],
-          "x": 330.2126,
-          "y": 622.4071,
-          "direction": 1
+          "x": 310.2126,
+          "y": 673.4071,
+          "direction": 4
         },
         "meta": {
           "updateAt": 1745498297183,
@@ -1803,8 +1824,8 @@
           "columnIds": [
             "y7mIA2j_HBZKM9Fe9yR2v"
           ],
-          "x": 899.3499,
-          "y": 817.4294,
+          "x": 1069.3499,
+          "y": 726.6293999999999,
           "direction": 1
         },
         "end": {
@@ -1812,8 +1833,8 @@
           "columnIds": [
             "qYPjNCSt7PHgpL65cX_Dl"
           ],
-          "x": 840.2126000000001,
-          "y": 622.4071,
+          "x": 565.2126,
+          "y": 749.4071,
           "direction": 2
         },
         "meta": {
@@ -1823,7 +1844,7 @@
       },
       "DqN3E3l5xsfe3Sa1XZ4Dn": {
         "id": "DqN3E3l5xsfe3Sa1XZ4Dn",
-        "identification": false,
+        "identification": true,
         "relationshipType": 16,
         "startRelationshipType": 2,
         "start": {
@@ -1831,18 +1852,18 @@
           "columnIds": [
             "aZV1EX4pI-WE6FSIeloqW"
           ],
-          "x": 128.05203333333333,
-          "y": 266.1023,
-          "direction": 8
+          "x": 587.2187,
+          "y": 98.1023,
+          "direction": 2
         },
         "end": {
           "tableId": "QRtSx4RMjyg8xmvY7GPrI",
           "columnIds": [
             "H9QsMBnhPHJx0fL86Anxg"
           ],
-          "x": 234.5602,
-          "y": 724.1082,
-          "direction": 4
+          "x": 829.5602,
+          "y": 126.1082,
+          "direction": 1
         },
         "meta": {
           "updateAt": 1745498495080,
@@ -1851,7 +1872,7 @@
       },
       "6-Qey6CFqsAcyC7k2hZ3n": {
         "id": "6-Qey6CFqsAcyC7k2hZ3n",
-        "identification": false,
+        "identification": true,
         "relationshipType": 16,
         "startRelationshipType": 2,
         "start": {
@@ -1859,17 +1880,17 @@
           "columnIds": [
             "y7mIA2j_HBZKM9Fe9yR2v"
           ],
-          "x": 899.3499,
-          "y": 873.4294,
-          "direction": 1
+          "x": 1480.3499,
+          "y": 659.4294,
+          "direction": 4
         },
         "end": {
           "tableId": "QRtSx4RMjyg8xmvY7GPrI",
           "columnIds": [
             "cyB0VtfkXoegatCzQQIfM"
           ],
-          "x": 447.5602,
-          "y": 788.1082,
+          "x": 1339.5602,
+          "y": 126.1082,
           "direction": 2
         },
         "meta": {
@@ -1887,18 +1908,18 @@
           "columnIds": [
             "y7mIA2j_HBZKM9Fe9yR2v"
           ],
-          "x": 1378.8499000000002,
-          "y": 789.4294,
-          "direction": 4
+          "x": 1069.3499,
+          "y": 861.0293999999998,
+          "direction": 1
         },
         "end": {
           "tableId": "TT8mGx9q7qEMOLs-p6KkS",
           "columnIds": [
             "mABxR9m0G66KTu3BI1ZAU"
           ],
-          "x": 1375.8909,
-          "y": 610.1892,
-          "direction": 1
+          "x": 1005.8909,
+          "y": 1161.1892,
+          "direction": 2
         },
         "meta": {
           "updateAt": 1745498578313,
@@ -1916,7 +1937,7 @@
             "aZV1EX4pI-WE6FSIeloqW"
           ],
           "x": 587.2187,
-          "y": 154.1023,
+          "y": 210.1023,
           "direction": 2
         },
         "end": {
@@ -1924,8 +1945,8 @@
           "columnIds": [
             "YN6wc1DOBjbxfESZ_gwha"
           ],
-          "x": 960.1924,
-          "y": 156.5341,
+          "x": 832.1924,
+          "y": 317.53409999999997,
           "direction": 1
         },
         "meta": {
@@ -1943,8 +1964,8 @@
           "columnIds": [
             "y7mIA2j_HBZKM9Fe9yR2v"
           ],
-          "x": 1104.8499000000002,
-          "y": 789.4294,
+          "x": 1206.3499,
+          "y": 659.4294,
           "direction": 4
         },
         "end": {
@@ -1952,8 +1973,8 @@
           "columnIds": [
             "r_rSI5a7OIWb5PA2M2Tm6"
           ],
-          "x": 1224.1924,
-          "y": 268.5341,
+          "x": 1096.1924,
+          "y": 429.53409999999997,
           "direction": 8
         },
         "meta": {
@@ -1965,904 +1986,5 @@
     "indexEntities": {},
     "indexColumnEntities": {},
     "memoEntities": {}
-  },
-  "lww": {
-    "8aFrB5iymo97MeKM6QOXI": [
-      "tableEntities",
-      1745495057231,
-      -1,
-      {
-        "name": 1745497997395,
-        "comment": 1745497285310
-      }
-    ],
-    "aZV1EX4pI-WE6FSIeloqW": [
-      "tableColumnEntities",
-      1745495070542,
-      -1,
-      {
-        "name": 1745495075768,
-        "dataType": 1745495079336,
-        "options(notNull)": 1746099323174,
-        "comment": 1745495148894,
-        "options(primaryKey)": 1745495154255,
-        "options(unique)": 1745495477053,
-        "options(autoIncrement)": 1746099058426
-      }
-    ],
-    "YFkO2aFJNflrJjch2ibcC": [
-      "tableColumnEntities",
-      1745495095016,
-      -1,
-      {
-        "name": 1745508777040,
-        "dataType": 1745507964546,
-        "options(notNull)": 1745495187171,
-        "options(unique)": 1745495483264,
-        "comment": 1745508937320
-      }
-    ],
-    "settings.databaseName": [
-      "settings",
-      -1,
-      -1,
-      {
-        "databaseName": 1745495114048
-      }
-    ],
-    "rFuK4POI0HqmEBuWNYhqn": [
-      "tableColumnEntities",
-      1745495194243,
-      -1,
-      {
-        "name": 1745495199473,
-        "dataType": 1745507969736,
-        "options(notNull)": 1745495203073,
-        "options(unique)": 1745495474715
-      }
-    ],
-    "RMRXCxwA-f__F7UIAucE5": [
-      "tableColumnEntities",
-      1745495194693,
-      -1,
-      {
-        "name": 1745495207289,
-        "dataType": 1745507973170,
-        "options(notNull)": 1745495213092,
-        "options(unique)": 1745495484839
-      }
-    ],
-    "KC2LG2pIYz-isDobOn1R_": [
-      "tableColumnEntities",
-      1745495195172,
-      -1,
-      {
-        "name": 1745495218072,
-        "dataType": 1745507975885,
-        "options(notNull)": 1745495226458,
-        "comment": 1745497303927,
-        "options(unique)": 1745508757860
-      }
-    ],
-    "4t9_a2SYDDVe_lAz7fSqk": [
-      "tableEntities",
-      1745497332799,
-      -1,
-      {
-        "name": 1745497371213,
-        "comment": 1745497379933
-      }
-    ],
-    "y7mIA2j_HBZKM9Fe9yR2v": [
-      "tableColumnEntities",
-      1745497380248,
-      -1,
-      {
-        "name": 1745497382254,
-        "dataType": 1745497386919,
-        "options(notNull)": 1746099335324,
-        "options(unique)": 1745507807452,
-        "options(autoIncrement)": 1746099082512,
-        "options(primaryKey)": 1745497395528
-      }
-    ],
-    "q9VC6MuGlAt2_fpvaU6YA": [
-      "tableColumnEntities",
-      1745497400900,
-      -1,
-      {
-        "name": 1745497419995,
-        "dataType": 1745507919978,
-        "options(notNull)": 1745497426024
-      }
-    ],
-    "5KP0ckgTfofol7kffxTVM": [
-      "tableColumnEntities",
-      1745497428903,
-      -1,
-      {
-        "name": 1745508135111,
-        "dataType": 1745507924045,
-        "options(notNull)": 1745497436494
-      }
-    ],
-    "GrSkMikwA3JQjbUJ-dQEL": [
-      "tableColumnEntities",
-      1745497438325,
-      1745497471911,
-      {
-        "name": 1745497448255
-      }
-    ],
-    "SbQWaRbeDbws5OYAat2iF": [
-      "tableEntities",
-      1745497478332,
-      -1,
-      {
-        "name": 1745497993195,
-        "comment": 1745497492539
-      }
-    ],
-    "bYBD1G5Rtzfd5bmHp1PSN": [
-      "tableColumnEntities",
-      1745497493721,
-      -1,
-      {
-        "name": 1745497523063,
-        "dataType": 1745497500936,
-        "options(notNull)": 1746099341190,
-        "options(unique)": 1745507802802,
-        "options(autoIncrement)": 1746099092399,
-        "options(primaryKey)": 1745497529306
-      }
-    ],
-    "OwoHz7vQm9Tnz7aJJdNd-": [
-      "tableColumnEntities",
-      1745497505916,
-      -1,
-      {
-        "name": 1745508109610,
-        "dataType": 1745507949109,
-        "options(notNull)": 1745497543220,
-        "options(unique)": 1745497546219
-      }
-    ],
-    "fHVQEcbx_VoYFmXnNu260": [
-      "tableColumnEntities",
-      1745497711276,
-      1745497737121,
-      {
-        "options(notNull)": 1745497711276,
-        "name": 1745497735792,
-        "dataType": 1745497711276,
-        "default": 1745497711276,
-        "comment": 1745497711276
-      }
-    ],
-    "n7z_XQfXY1finPSoUd9EW": [
-      "tableColumnEntities",
-      1745497746765,
-      1745497762918,
-      {
-        "options(notNull)": 1745497746765,
-        "name": 1745497746765,
-        "dataType": 1745497746765,
-        "default": 1745497746765,
-        "comment": 1745497746765
-      }
-    ],
-    "jxmmoPgOw5fyFw6AqcBCS": [
-      "tableColumnEntities",
-      1745497787833,
-      -1,
-      {
-        "options(notNull)": 1745497787833,
-        "name": 1745497799559,
-        "dataType": 1745497787833,
-        "default": 1745497787833,
-        "comment": 1745497787833
-      }
-    ],
-    "4EYlb6_xLtzqrHQIspM67": [
-      "relationshipEntities",
-      1745497787833,
-      -1,
-      {}
-    ],
-    "_CIKzC1_ech2NHfwtp4ZP": [
-      "tableEntities",
-      1745497833116,
-      -1,
-      {
-        "name": 1745497975933,
-        "comment": 1745497842987
-      }
-    ],
-    "7-m0nv5D2FbXOnd4f4Bgm": [
-      "tableColumnEntities",
-      1745497844125,
-      -1,
-      {
-        "name": 1745497845159,
-        "dataType": 1745497848337,
-        "options(notNull)": 1746099342873,
-        "options(unique)": 1745507804573,
-        "options(autoIncrement)": 1746099085588,
-        "options(primaryKey)": 1745497851519
-      }
-    ],
-    "PZNJcHrv12XoDKy1E94EA": [
-      "tableColumnEntities",
-      1745497853138,
-      -1,
-      {
-        "name": 1745508112115,
-        "dataType": 1745507955845,
-        "options(notNull)": 1745497859174,
-        "options(unique)": 1745497860684
-      }
-    ],
-    "7hHdemvf8tf1gBG5k8EXx": [
-      "tableColumnEntities",
-      1745497867939,
-      -1,
-      {
-        "options(notNull)": 1745497867939,
-        "name": 1745497980459,
-        "dataType": 1745497867939,
-        "default": 1745497867939,
-        "comment": 1745497867939
-      }
-    ],
-    "h_ZvyjoEt3T_6gYI1eCE_": [
-      "relationshipEntities",
-      1745497867939,
-      -1,
-      {}
-    ],
-    "PoVTyDcupvCwdz-QrJw7w": [
-      "tableEntities",
-      1745497874393,
-      -1,
-      {
-        "name": 1745497882373,
-        "comment": 1745497885874
-      }
-    ],
-    "mqVnVLgS3FSA4zpKu285m": [
-      "tableColumnEntities",
-      1745497886828,
-      1745497918696,
-      {
-        "name": 1745497888254,
-        "dataType": 1745497893699,
-        "options(notNull)": 1745497894329,
-        "options(unique)": 1745497894674,
-        "options(autoIncrement)": 1745497895006,
-        "comment": 1745497897344
-      }
-    ],
-    "Y8byxGDS3por4Rl1B6n-g": [
-      "tableColumnEntities",
-      1745497901318,
-      -1,
-      {
-        "name": 1745508139864,
-        "dataType": 1745507932267,
-        "options(notNull)": 1745497914818
-      }
-    ],
-    "LZTT3T0iLrGsGDiWojy6n": [
-      "tableColumnEntities",
-      1745497930814,
-      -1,
-      {
-        "options(notNull)": 1745497930814,
-        "name": 1745497944939,
-        "dataType": 1745497930814,
-        "default": 1745497930814,
-        "comment": 1745497930814,
-        "options(primaryKey)": 1746098920727
-      }
-    ],
-    "CWCO8DL1lezTXlkDq3gZb": [
-      "relationshipEntities",
-      1745497930815,
-      -1,
-      {}
-    ],
-    "LjZoHLvA6UqrBIsKzV7kT": [
-      "tableEntities",
-      1745498004461,
-      -1,
-      {
-        "name": 1745498008316,
-        "comment": 1745498016766
-      }
-    ],
-    "2CuhpG8itwxd_cODm36Ap": [
-      "tableColumnEntities",
-      1745498012080,
-      -1,
-      {
-        "name": 1745508151790,
-        "dataType": 1745507944685,
-        "options(notNull)": 1745498052011
-      }
-    ],
-    "33K9rBXrTQkvyxtO1pA_t": [
-      "tableColumnEntities",
-      1745498056360,
-      -1,
-      {
-        "name": 1745498059356,
-        "dataType": 1745506990094,
-        "options(notNull)": 1745498069666,
-        "comment": 1745498095725
-      }
-    ],
-    "_gwHoDh2lO7fUm8OfzcUV": [
-      "tableColumnEntities",
-      1745498106077,
-      -1,
-      {
-        "options(notNull)": 1745498106077,
-        "name": 1745498113646,
-        "dataType": 1745498106077,
-        "default": 1745498106077,
-        "comment": 1745498106077,
-        "options(primaryKey)": 1745506972530
-      }
-    ],
-    "FJ4uWPOikKX9qZ7CLmTB8": [
-      "relationshipEntities",
-      1745498106077,
-      -1,
-      {}
-    ],
-    "IrobFUndU4WWxGROXjnhj": [
-      "tableColumnEntities",
-      1745498120402,
-      -1,
-      {
-        "options(notNull)": 1745498120402,
-        "name": 1745498124526,
-        "dataType": 1745498120402,
-        "default": 1745498120402,
-        "comment": 1745498120402,
-        "options(primaryKey)": 1745506974014
-      }
-    ],
-    "rnhw3RJ5ONfpMD6O3Y93T": [
-      "relationshipEntities",
-      1745498120402,
-      -1,
-      {}
-    ],
-    "7C0PRYdyvSrdq4I1cBFTL": [
-      "tableEntities",
-      1745498264053,
-      -1,
-      {
-        "name": 1745498271659,
-        "comment": 1745498280036
-      }
-    ],
-    "HlcQFfMEtyLNioD7eK8Ll": [
-      "tableColumnEntities",
-      1745498265327,
-      1745498290385,
-      {}
-    ],
-    "kwiSsLPW9j-cKxdERkjtP": [
-      "tableColumnEntities",
-      1745498297181,
-      -1,
-      {
-        "options(notNull)": 1745498297181,
-        "name": 1745498304963,
-        "dataType": 1745498297181,
-        "default": 1745498297181,
-        "comment": 1745498297181,
-        "options(primaryKey)": 1746098928206
-      }
-    ],
-    "YynzCf6FhZdh0LInvD3cg": [
-      "relationshipEntities",
-      1745498297181,
-      -1,
-      {}
-    ],
-    "3y7H9HgdCD7DZHDRfcsbd": [
-      "tableColumnEntities",
-      1745498299505,
-      1745498301179,
-      {
-        "options(primaryKey)": 1745498299505
-      }
-    ],
-    "qYPjNCSt7PHgpL65cX_Dl": [
-      "tableColumnEntities",
-      1745498314779,
-      -1,
-      {
-        "options(notNull)": 1745498314779,
-        "name": 1745498318250,
-        "dataType": 1745498314779,
-        "default": 1745498314779,
-        "comment": 1745498314779,
-        "options(primaryKey)": 1746098928971
-      }
-    ],
-    "x6Efy3vQ-8CpwLvovCHrV": [
-      "relationshipEntities",
-      1745498314779,
-      -1,
-      {}
-    ],
-    "QRtSx4RMjyg8xmvY7GPrI": [
-      "tableEntities",
-      1745498474160,
-      -1,
-      {
-        "name": 1745498478615,
-        "comment": 1745498481054
-      }
-    ],
-    "VObppcT66U8dAJwRHZdKq": [
-      "tableColumnEntities",
-      1745498481827,
-      1745498486323,
-      {}
-    ],
-    "H9QsMBnhPHJx0fL86Anxg": [
-      "tableColumnEntities",
-      1745498495078,
-      -1,
-      {
-        "options(notNull)": 1745498495078,
-        "name": 1745498501372,
-        "dataType": 1745498495078,
-        "default": 1745498495078,
-        "comment": 1745498495078,
-        "options(primaryKey)": 1746098924545
-      }
-    ],
-    "DqN3E3l5xsfe3Sa1XZ4Dn": [
-      "relationshipEntities",
-      1745498495078,
-      -1,
-      {}
-    ],
-    "cyB0VtfkXoegatCzQQIfM": [
-      "tableColumnEntities",
-      1745498508787,
-      -1,
-      {
-        "options(notNull)": 1745498508787,
-        "name": 1745498515426,
-        "dataType": 1745498508787,
-        "default": 1745498508787,
-        "comment": 1745498508787,
-        "options(primaryKey)": 1746098925611
-      }
-    ],
-    "6-Qey6CFqsAcyC7k2hZ3n": [
-      "relationshipEntities",
-      1745498508787,
-      -1,
-      {}
-    ],
-    "TT8mGx9q7qEMOLs-p6KkS": [
-      "tableEntities",
-      1745498558417,
-      -1,
-      {
-        "name": 1745508015738,
-        "comment": 1745498570855
-      }
-    ],
-    "h98uEhJOeet6KzjfOlBth": [
-      "tableColumnEntities",
-      1745498571588,
-      -1,
-      {
-        "name": 1745498618628,
-        "dataType": 1745498620518,
-        "options(notNull)": 1745498621176,
-        "comment": 1745498629954
-      }
-    ],
-    "mABxR9m0G66KTu3BI1ZAU": [
-      "tableColumnEntities",
-      1745498578312,
-      -1,
-      {
-        "options(notNull)": 1745498578312,
-        "name": 1745498583347,
-        "dataType": 1745498578312,
-        "default": 1745498578312,
-        "comment": 1745498578312,
-        "options(primaryKey)": 1746098923108
-      }
-    ],
-    "K9O1srgAORx6fZAajCiFB": [
-      "relationshipEntities",
-      1745498578312,
-      -1,
-      {}
-    ],
-    "FJv128iZQYa6bUl9XgjCt": [
-      "tableColumnEntities",
-      1745498630483,
-      -1,
-      {
-        "name": 1745498634063,
-        "dataType": 1745498635951,
-        "options(notNull)": 1745498636778,
-        "comment": 1745498641148
-      }
-    ],
-    "ZP3qUs4cZ1uQx7IswO1Fi": [
-      "tableColumnEntities",
-      1745506955989,
-      -1,
-      {
-        "name": 1745506959449,
-        "dataType": 1745506962044,
-        "options(notNull)": 1746099338538,
-        "options(unique)": 1745507812792,
-        "options(autoIncrement)": 1746099060897,
-        "options(primaryKey)": 1745506966560
-      }
-    ],
-    "SpystaxktjoZuDCNluhs2": [
-      "tableColumnEntities",
-      1745506994684,
-      -1,
-      {
-        "name": 1745508277399,
-        "dataType": 1745508277399,
-        "options(notNull)": 1745508743353,
-        "comment": 1745508277399,
-        "options(unique)": 1745508744463,
-        "options(autoIncrement)": 1745508745033,
-        "default": 1745508898740
-      }
-    ],
-    "aQ-DiY_134I285CtsweJ4": [
-      "tableEntities",
-      1745507027070,
-      -1,
-      {
-        "name": 1746533343353,
-        "comment": 1746533372365
-      }
-    ],
-    "c8Bkdi6BJ_wN4BCR-3eif": [
-      "tableColumnEntities",
-      1745507047081,
-      -1,
-      {
-        "name": 1746533455627,
-        "dataType": 1745507057626,
-        "options(notNull)": 1745507058721,
-        "default": 1746533458313
-      }
-    ],
-    "YN6wc1DOBjbxfESZ_gwha": [
-      "tableColumnEntities",
-      1745507072632,
-      -1,
-      {
-        "options(notNull)": 1745507072632,
-        "name": 1745507092532,
-        "dataType": 1745507072632,
-        "default": 1745507072632,
-        "comment": 1745507072632,
-        "options(primaryKey)": 1746098926361
-      }
-    ],
-    "hFZ9sFkiYbsCBR-qxEQb0": [
-      "relationshipEntities",
-      1745507072633,
-      -1,
-      {}
-    ],
-    "nlGqItKDmvYXhsTBFwqx5": [
-      "tableColumnEntities",
-      1745507078197,
-      1745507081340,
-      {
-        "options(notNull)": 1745507078197,
-        "name": 1745507078197,
-        "dataType": 1745507078197,
-        "default": 1745507078197,
-        "comment": 1745507078197
-      }
-    ],
-    "AM58umJfwjf2R609bUFA5": [
-      "tableColumnEntities",
-      1745507085652,
-      1745507088676,
-      {
-        "options(notNull)": 1745507085652,
-        "name": 1745507085652,
-        "dataType": 1745507085652,
-        "default": 1745507085652,
-        "comment": 1745507085652
-      }
-    ],
-    "r_rSI5a7OIWb5PA2M2Tm6": [
-      "tableColumnEntities",
-      1745507097831,
-      -1,
-      {
-        "options(notNull)": 1745507097831,
-        "name": 1745507103511,
-        "dataType": 1745507097831,
-        "default": 1745507097831,
-        "comment": 1745507097831,
-        "options(primaryKey)": 1746098927051
-      }
-    ],
-    "wpQoDXEiy2ArrkoCqJ2Fx": [
-      "relationshipEntities",
-      1745507097832,
-      -1,
-      {}
-    ],
-    "E8ARIRcuO3CQ6XjAGb9bi": [
-      "tableColumnEntities",
-      1745507160030,
-      -1,
-      {
-        "name": 1745507163466,
-        "dataType": 1745507168386,
-        "options(notNull)": 1745507169362,
-        "default": 1745508888132
-      }
-    ],
-    "8tz3LfjKIvoR181yNvIz4": [
-      "tableColumnEntities",
-      1745508166114,
-      -1,
-      {
-        "name": 1745508168891,
-        "dataType": 1745508171649,
-        "options(notNull)": 1745508172534,
-        "default": 1745508896010
-      }
-    ],
-    "9thSvk11o4L2mrhR5RjNm": [
-      "tableColumnEntities",
-      1745508174709,
-      -1,
-      {
-        "name": 1745508179016,
-        "dataType": 1745508192934
-      }
-    ],
-    "PQR5v7z-Zw8WnzncBwO0d": [
-      "tableColumnEntities",
-      1745508205930,
-      -1,
-      {
-        "name": 1745508209990,
-        "dataType": 1745508212105,
-        "options(notNull)": 1745508213214,
-        "default": 1745508893054
-      }
-    ],
-    "zDUaZts6zMEyhxenWUtPu": [
-      "tableColumnEntities",
-      1745508214174,
-      -1,
-      {
-        "name": 1745508216410,
-        "dataType": 1745508218916
-      }
-    ],
-    "CNX12raDftYUgrP6baZjA": [
-      "tableColumnEntities",
-      1745508253205,
-      1745508284066,
-      {
-        "name": 1745508255607,
-        "dataType": 1745508258200,
-        "options(notNull)": 1745508259040
-      }
-    ],
-    "7987_F4x-uuSEoRAd0pgp": [
-      "tableColumnEntities",
-      1745508261335,
-      1745508283217,
-      {
-        "name": 1745508263840,
-        "dataType": 1745508280805
-      }
-    ],
-    "W9JLIXKYfvwzM7nbcUymM": [
-      "tableColumnEntities",
-      1745508273490,
-      1745508277399,
-      {
-        "name": 1745508273490,
-        "dataType": 1745508273490,
-        "options(notNull)": 1745508273490,
-        "options(unique)": 1745508273490,
-        "options(autoIncrement)": 1745508273490,
-        "default": 1745508273490,
-        "comment": 1745508273490
-      }
-    ],
-    "VdVG-GxuRGvG6_zfqTjXu": [
-      "tableColumnEntities",
-      1745508284768,
-      -1,
-      {
-        "name": 1745508284768,
-        "dataType": 1745508284768,
-        "default": 1745508880278,
-        "comment": 1745508284768,
-        "options(notNull)": 1745508284768,
-        "options(unique)": 1745508284768,
-        "options(autoIncrement)": 1745508284768
-      }
-    ],
-    "SO42rWN8-3tfCzsRImDTU": [
-      "tableColumnEntities",
-      1745508284768,
-      -1,
-      {
-        "name": 1745508284768,
-        "dataType": 1745508284768,
-        "default": 1745508284768,
-        "comment": 1745508284768,
-        "options(notNull)": 1745508284768,
-        "options(unique)": 1745508756599,
-        "options(autoIncrement)": 1745508284768
-      }
-    ],
-    "6MmB2EYoI2cu4yi23bMvK": [
-      "tableColumnEntities",
-      1746098908671,
-      -1,
-      {
-        "name": 1746098912158,
-        "dataType": 1746098914831,
-        "options(notNull)": 1746099336871,
-        "options(primaryKey)": 1746098916656,
-        "options(autoIncrement)": 1746099079363
-      }
-    ],
-    "AxmxKSsILSP0gONgkJopv": [
-      "tableColumnEntities",
-      1746098938349,
-      -1,
-      {
-        "name": 1746098938349,
-        "dataType": 1746098938349,
-        "default": 1746098938349,
-        "comment": 1746098938349,
-        "options(notNull)": 1746099327555,
-        "options(unique)": 1746098938349,
-        "options(autoIncrement)": 1746099076647,
-        "options(primaryKey)": 1746098941878
-      }
-    ],
-    "GgW95yo8hI83OdCmTVU61": [
-      "tableColumnEntities",
-      1746098944368,
-      -1,
-      {
-        "name": 1746098944368,
-        "dataType": 1746098944368,
-        "default": 1746098944368,
-        "comment": 1746098944368,
-        "options(notNull)": 1746099325829,
-        "options(unique)": 1746098944368,
-        "options(autoIncrement)": 1746099074502,
-        "options(primaryKey)": 1746098950063
-      }
-    ],
-    "aS7iktFYO7QmQnpU_jgmw": [
-      "tableColumnEntities",
-      1746098954166,
-      -1,
-      {
-        "name": 1746098954166,
-        "dataType": 1746098954166,
-        "default": 1746098954166,
-        "comment": 1746098954166,
-        "options(notNull)": 1746099329235,
-        "options(unique)": 1746098954166,
-        "options(autoIncrement)": 1746099072674,
-        "options(primaryKey)": 1746098957219
-      }
-    ],
-    "-PXNhiZzRvwfVEOsVnoNK": [
-      "tableColumnEntities",
-      1746098960581,
-      -1,
-      {
-        "name": 1746098960581,
-        "dataType": 1746098960581,
-        "default": 1746098960581,
-        "comment": 1746098960581,
-        "options(notNull)": 1746099331189,
-        "options(unique)": 1746098960581,
-        "options(autoIncrement)": 1746099062802,
-        "options(primaryKey)": 1746098965454
-      }
-    ],
-    "skm1SlUBPVALol5gUJUeT": [
-      "tableColumnEntities",
-      1746099068311,
-      1746099069533,
-      {}
-    ],
-    "MtBl8Va1Lk-mtDw2Duni6": [
-      "tableColumnEntities",
-      1746099572873,
-      1746099635758,
-      {
-        "options(notNull)": 1746099572873,
-        "name": 1746099588867,
-        "dataType": 1746099572873,
-        "default": 1746099572873,
-        "comment": 1746099572873,
-        "options(primaryKey)": 1746099593456
-      }
-    ],
-    "47uNiw3n7D7jKwSXEZgyr": [
-      "tableColumnEntities",
-      1746533389975,
-      -1,
-      {
-        "name": 1746533396901,
-        "dataType": 1746533402678,
-        "options(notNull)": 1746533403787,
-        "default": 1746533406984,
-        "comment": 1746533469208
-      }
-    ],
-    "4cei7VYy6xfmBuv8La_HL": [
-      "tableColumnEntities",
-      1746533407745,
-      -1,
-      {
-        "name": 1746533411737,
-        "dataType": 1746533412626,
-        "options(notNull)": 1746533413657,
-        "default": 1746533418023,
-        "comment": 1746533422137
-      }
-    ],
-    "TS3M0ZXZYWC-02VuuHhGJ": [
-      "tableColumnEntities",
-      1746533423139,
-      -1,
-      {
-        "name": 1746533442698,
-        "dataType": 1746533442698,
-        "options(notNull)": 1746533442698,
-        "options(unique)": 1746533461885,
-        "options(autoIncrement)": 1746533463968,
-        "default": 1746533446423,
-        "comment": 1746533479257
-      }
-    ],
-    "eQVTYYo6DkFvrgl8uc08f": [
-      "tableColumnEntities",
-      1747190800777,
-      -1,
-      {
-        "name": 1747190803475,
-        "dataType": 1747190814022,
-        "options(notNull)": 1747190816167,
-        "comment": 1747190833887
-      }
-    ]
   }
 }

--- a/src/main/java/com/upstage/devup/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/upstage/devup/bookmark/controller/BookmarkController.java
@@ -2,6 +2,7 @@ package com.upstage.devup.bookmark.controller;
 
 import com.upstage.devup.auth.config.AuthenticatedUser;
 import com.upstage.devup.bookmark.dto.BookmarkResponseDto;
+import com.upstage.devup.bookmark.dto.BookmarksQueryDto;
 import com.upstage.devup.bookmark.service.BookmarkService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +16,29 @@ public class BookmarkController {
 
     private final BookmarkService bookmarkService;
 
+    /**
+     * 북마크 목록 조회
+     *
+     * @param user       로그인한 사용자 정보
+     * @param pageNumber 페이지 번호
+     * @return 조회된 북마크 목록
+     */
+    @GetMapping
+    public ResponseEntity<BookmarksQueryDto> getBookmarks(
+            @AuthenticationPrincipal AuthenticatedUser user,
+            @RequestParam Integer pageNumber
+    ) {
+        BookmarksQueryDto result = bookmarkService.getBookmarks(user.getUserId(), pageNumber);
+        return ResponseEntity.ok(result);
+    }
+
+    /**
+     * 신규 북마크 등록
+     *
+     * @param user       로그인한 사용자 정보
+     * @param questionId 등록할 면접 질문 ID
+     * @return 등록된 북마크 정보
+     */
     @PostMapping("/{questionId}")
     public ResponseEntity<BookmarkResponseDto> createBookmark(
             @AuthenticationPrincipal AuthenticatedUser user,
@@ -24,6 +48,13 @@ public class BookmarkController {
         return ResponseEntity.ok(result);
     }
 
+    /**
+     * 북마크 삭제
+     *
+     * @param user       로그인한 사용자 정보
+     * @param questionId 삭제할 면접 질문 ID
+     * @return 삭제된 북마크 정보
+     */
     @DeleteMapping("/{questionId}")
     public ResponseEntity<BookmarkResponseDto> deleteBookmark(
             @AuthenticationPrincipal AuthenticatedUser user,

--- a/src/main/java/com/upstage/devup/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/upstage/devup/bookmark/controller/BookmarkController.java
@@ -1,0 +1,29 @@
+package com.upstage.devup.bookmark.controller;
+
+import com.upstage.devup.auth.config.AuthenticatedUser;
+import com.upstage.devup.bookmark.dto.BookmarkResponseDto;
+import com.upstage.devup.bookmark.service.BookmarkService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/bookmarks")
+@RequiredArgsConstructor
+public class BookmarkController {
+
+    private final BookmarkService bookmarkService;
+
+    @PostMapping("/{questionId}")
+    public ResponseEntity<BookmarkResponseDto> createBookmark(
+            @AuthenticationPrincipal AuthenticatedUser user,
+            @PathVariable Long questionId
+    ) {
+        BookmarkResponseDto result = bookmarkService.registerBookmark(user.getUserId(), questionId);
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/com/upstage/devup/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/upstage/devup/bookmark/controller/BookmarkController.java
@@ -6,10 +6,7 @@ import com.upstage.devup.bookmark.service.BookmarkService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/bookmarks")
@@ -24,6 +21,15 @@ public class BookmarkController {
             @PathVariable Long questionId
     ) {
         BookmarkResponseDto result = bookmarkService.registerBookmark(user.getUserId(), questionId);
+        return ResponseEntity.ok(result);
+    }
+
+    @DeleteMapping("/{questionId}")
+    public ResponseEntity<BookmarkResponseDto> deleteBookmark(
+            @AuthenticationPrincipal AuthenticatedUser user,
+            @PathVariable Long questionId
+    ) {
+        BookmarkResponseDto result = bookmarkService.deleteBookmark(user.getUserId(), questionId);
         return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/com/upstage/devup/bookmark/dto/BookmarkDetails.java
+++ b/src/main/java/com/upstage/devup/bookmark/dto/BookmarkDetails.java
@@ -1,0 +1,24 @@
+package com.upstage.devup.bookmark.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+
+public record BookmarkDetails(
+        Long questionId,
+        String title,
+        String category,
+        String level,
+
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime createdAt
+) {
+
+    public BookmarkDetails(Long questionId, String title, String category, String level, LocalDateTime createdAt) {
+        this.questionId = questionId;
+        this.title = title;
+        this.category = category;
+        this.level = level;
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/upstage/devup/bookmark/dto/BookmarkResponseDto.java
+++ b/src/main/java/com/upstage/devup/bookmark/dto/BookmarkResponseDto.java
@@ -1,5 +1,6 @@
 package com.upstage.devup.bookmark.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,6 +14,8 @@ public class BookmarkResponseDto {
 
     private Long userId;
     private Long questionId;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime createdAt;
 
 }

--- a/src/main/java/com/upstage/devup/bookmark/dto/BookmarkResponseDto.java
+++ b/src/main/java/com/upstage/devup/bookmark/dto/BookmarkResponseDto.java
@@ -1,0 +1,18 @@
+package com.upstage.devup.bookmark.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class BookmarkResponseDto {
+
+    private Long userId;
+    private Long questionId;
+    private LocalDateTime createdAt;
+
+}

--- a/src/main/java/com/upstage/devup/bookmark/dto/BookmarksQueryDto.java
+++ b/src/main/java/com/upstage/devup/bookmark/dto/BookmarksQueryDto.java
@@ -1,0 +1,32 @@
+package com.upstage.devup.bookmark.dto;
+
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+public class BookmarksQueryDto {
+
+    private final List<BookmarkDetails> contents;
+
+    private final int currentPageNumber;
+    private final int size;
+    private final int totalPages;
+    private final long totalElements;
+
+    private final boolean hasPrevious;
+    private final boolean hasNext;
+
+    public BookmarksQueryDto(Page<BookmarkDetails> page) {
+        this.contents = page.getContent();
+
+        this.currentPageNumber = page.getNumber();
+        this.size = page.getSize();
+        this.totalPages = page.getTotalPages();
+        this.totalElements = page.getTotalElements();
+
+        this.hasPrevious = page.hasPrevious();
+        this.hasNext = page.hasNext();
+    }
+}

--- a/src/main/java/com/upstage/devup/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/upstage/devup/bookmark/repository/BookmarkRepository.java
@@ -1,0 +1,15 @@
+package com.upstage.devup.bookmark.repository;
+
+import com.upstage.devup.global.domain.id.BookmarkId;
+import com.upstage.devup.global.entity.Bookmark;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface BookmarkRepository extends JpaRepository<Bookmark, BookmarkId> {
+    boolean existsByUserIdAndQuestionId(long userId, long questionId);
+
+    Optional<Bookmark> findByUserIdAndQuestionId(long userId, long questionId);
+}

--- a/src/main/java/com/upstage/devup/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/upstage/devup/bookmark/repository/BookmarkRepository.java
@@ -1,8 +1,12 @@
 package com.upstage.devup.bookmark.repository;
 
+import com.upstage.devup.bookmark.dto.BookmarkDetails;
 import com.upstage.devup.global.domain.id.BookmarkId;
 import com.upstage.devup.global.entity.Bookmark;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -12,4 +16,17 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, BookmarkId> 
     boolean existsByUserIdAndQuestionId(long userId, long questionId);
 
     Optional<Bookmark> findByUserIdAndQuestionId(long userId, long questionId);
+
+    @Query("""
+        SELECT new com.upstage.devup.bookmark.dto.BookmarkDetails(
+                q.id, q.title, c.category, l.level, b.createdAt
+                )
+                FROM Bookmark b
+                JOIN b.question q
+                JOIN q.category c
+                JOIN q.level l
+                WHERE b.user.id = :userId
+    """)
+    Page<BookmarkDetails> findBookmarkDetailsByUserId(long userId, Pageable pageable);
+
 }

--- a/src/main/java/com/upstage/devup/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/upstage/devup/bookmark/service/BookmarkService.java
@@ -1,0 +1,68 @@
+package com.upstage.devup.bookmark.service;
+
+import com.upstage.devup.bookmark.dto.BookmarkResponseDto;
+import com.upstage.devup.bookmark.repository.BookmarkRepository;
+import com.upstage.devup.global.domain.id.BookmarkId;
+import com.upstage.devup.global.entity.Bookmark;
+import com.upstage.devup.global.entity.Question;
+import com.upstage.devup.global.entity.User;
+import com.upstage.devup.global.exception.EntityNotFoundException;
+import com.upstage.devup.question.repository.QuestionRepository;
+import com.upstage.devup.user.account.repository.UserAccountRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BookmarkService {
+
+    private final BookmarkRepository bookmarkRepository;
+    private final UserAccountRepository userAccountRepository;
+    private final QuestionRepository questionRepository;
+
+    // TODO: 북마크 등록
+
+    /**
+     * 신규 북마크 등록
+     * (이미 등록된 북마크가 있는 경우 정상 등록 처리)
+     *
+     * @param userId     사용자 ID
+     * @param questionId 면접 질문 ID
+     * @return 저장된 북마크 정보
+     */
+    public BookmarkResponseDto registerBookmark(long userId, long questionId) {
+
+        Bookmark bookmark = bookmarkRepository
+                .findByUserIdAndQuestionId(userId, questionId)
+                .orElseGet(() -> {
+                    User user = userAccountRepository.findById(userId)
+                            .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 회원입니다."));
+
+                    Question question = questionRepository.findById(questionId)
+                            .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 질문입니다."));
+
+                    return bookmarkRepository.save(
+                            Bookmark.builder()
+                                    .id(new BookmarkId(userId, questionId))
+                                    .user(user)
+                                    .question(question)
+                                    .createdAt(LocalDateTime.now())
+                                    .build()
+                    );
+                });
+
+        return convertToDto(bookmark);
+    }
+
+    private BookmarkResponseDto convertToDto(Bookmark bookmark) {
+        return BookmarkResponseDto.builder()
+                .userId(bookmark.getUser().getId())
+                .questionId(bookmark.getQuestion().getId())
+                .createdAt(bookmark.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/upstage/devup/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/upstage/devup/bookmark/service/BookmarkService.java
@@ -24,8 +24,6 @@ public class BookmarkService {
     private final UserAccountRepository userAccountRepository;
     private final QuestionRepository questionRepository;
 
-    // TODO: 북마크 등록
-
     /**
      * 신규 북마크 등록
      * (이미 등록된 북마크가 있는 경우 정상 등록 처리)
@@ -56,6 +54,23 @@ public class BookmarkService {
                 });
 
         return convertToDto(bookmark);
+    }
+
+    /**
+     * 북마크 삭제
+     *
+     * @param userId 사용자 ID
+     * @param questionId 면접 질문 ID
+     * @return 삭제된 북마크 정보
+     */
+    public BookmarkResponseDto deleteBookmark(long userId, long questionId) {
+        Bookmark entity = bookmarkRepository
+                .findByUserIdAndQuestionId(userId, questionId)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 북마크입니다."));
+
+        bookmarkRepository.delete(entity);
+
+        return convertToDto(entity);
     }
 
     private BookmarkResponseDto convertToDto(Bookmark bookmark) {

--- a/src/main/java/com/upstage/devup/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/upstage/devup/bookmark/service/BookmarkService.java
@@ -1,6 +1,8 @@
 package com.upstage.devup.bookmark.service;
 
+import com.upstage.devup.bookmark.dto.BookmarkDetails;
 import com.upstage.devup.bookmark.dto.BookmarkResponseDto;
+import com.upstage.devup.bookmark.dto.BookmarksQueryDto;
 import com.upstage.devup.bookmark.repository.BookmarkRepository;
 import com.upstage.devup.global.domain.id.BookmarkId;
 import com.upstage.devup.global.entity.Bookmark;
@@ -11,6 +13,9 @@ import com.upstage.devup.question.repository.QuestionRepository;
 import com.upstage.devup.user.account.repository.UserAccountRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -23,6 +28,28 @@ public class BookmarkService {
     private final BookmarkRepository bookmarkRepository;
     private final UserAccountRepository userAccountRepository;
     private final QuestionRepository questionRepository;
+
+    private static final int BOOKMARKS_PER_PAGE = 10;
+
+    /**
+     * 북마크 목록 조회
+     *
+     * @param userId     사용자 ID
+     * @param pageNumber 페이지 번호
+     * @return 조회된 북마크 목록
+     */
+    public BookmarksQueryDto getBookmarks(long userId, int pageNumber) {
+        Page<BookmarkDetails> result = bookmarkRepository.findBookmarkDetailsByUserId(
+                userId,
+                PageRequest.of(
+                        Math.max(0, pageNumber),
+                        BOOKMARKS_PER_PAGE,
+                        Sort.by(Sort.Direction.DESC, "createdAt")
+                )
+        );
+
+        return new BookmarksQueryDto(result);
+    }
 
     /**
      * 신규 북마크 등록
@@ -59,7 +86,7 @@ public class BookmarkService {
     /**
      * 북마크 삭제
      *
-     * @param userId 사용자 ID
+     * @param userId     사용자 ID
      * @param questionId 면접 질문 ID
      * @return 삭제된 북마크 정보
      */

--- a/src/main/java/com/upstage/devup/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/upstage/devup/bookmark/service/BookmarkService.java
@@ -91,6 +91,7 @@ public class BookmarkService {
      * @return 삭제된 북마크 정보
      */
     public BookmarkResponseDto deleteBookmark(long userId, long questionId) {
+
         Bookmark entity = bookmarkRepository
                 .findByUserIdAndQuestionId(userId, questionId)
                 .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 북마크입니다."));
@@ -106,5 +107,9 @@ public class BookmarkService {
                 .questionId(bookmark.getQuestion().getId())
                 .createdAt(bookmark.getCreatedAt())
                 .build();
+    }
+
+    public boolean checkBookmarkIsRegistered(long userId, long questionId) {
+        return bookmarkRepository.existsByUserIdAndQuestionId(userId, questionId);
     }
 }

--- a/src/main/java/com/upstage/devup/global/domain/id/BookmarkId.java
+++ b/src/main/java/com/upstage/devup/global/domain/id/BookmarkId.java
@@ -1,0 +1,36 @@
+package com.upstage.devup.global.domain.id;
+
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@Embeddable
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BookmarkId implements Serializable {
+
+    private Long userId;
+    private Long questionId;
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (!(obj instanceof BookmarkId temp)) {
+            return false;
+        }
+
+        return Objects.equals(userId, temp.userId) && Objects.equals(questionId, temp.questionId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(userId, questionId);
+    }
+}

--- a/src/main/java/com/upstage/devup/global/entity/Bookmark.java
+++ b/src/main/java/com/upstage/devup/global/entity/Bookmark.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import java.time.LocalDateTime;
 
 @Entity
+@Table(name = "bookmarks")
 @Builder
 @Getter
 public class Bookmark {

--- a/src/main/java/com/upstage/devup/global/entity/Bookmark.java
+++ b/src/main/java/com/upstage/devup/global/entity/Bookmark.java
@@ -1,0 +1,46 @@
+package com.upstage.devup.global.entity;
+
+import com.upstage.devup.global.domain.id.BookmarkId;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Builder
+@Getter
+public class Bookmark {
+
+    @EmbeddedId
+    private BookmarkId id;
+
+    @MapsId("userId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @MapsId("questionId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id", nullable = false)
+    private Question question;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    public Bookmark() {}
+
+    public Bookmark(User user, Question question, LocalDateTime createdAt) {
+        this.id = new BookmarkId(user.getId(), question.getId());
+        this.user = user;
+        this.question = question;
+        this.createdAt = createdAt;
+    }
+
+    public Bookmark(BookmarkId id, User user, Question question, LocalDateTime createdAt) {
+        this.id = id;
+        this.user = user;
+        this.question = question;
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/upstage/devup/global/entity/Question.java
+++ b/src/main/java/com/upstage/devup/global/entity/Question.java
@@ -1,5 +1,6 @@
 package com.upstage.devup.global.entity;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -35,8 +36,10 @@ public class Question {
     private Level level;
 
     @Column(nullable = false)
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime createdAt;
 
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime modifiedAt;
 
 }

--- a/src/main/java/com/upstage/devup/question/dto/QuestionDetailDto.java
+++ b/src/main/java/com/upstage/devup/question/dto/QuestionDetailDto.java
@@ -17,6 +17,7 @@ public class QuestionDetailDto {
     private String category;
     private String level;
 
+    private boolean isBookmarked;
 
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime createdAt;

--- a/src/main/java/com/upstage/devup/user/answer/service/UserAnswerSaveService.java
+++ b/src/main/java/com/upstage/devup/user/answer/service/UserAnswerSaveService.java
@@ -48,7 +48,7 @@ public class UserAnswerSaveService {
             throw new EntityNotFoundException("사용자 정보를 찾을 수 없습니다.");
         }
 
-        QuestionDetailDto questionDetailDto = questionService.getQuestion(request.getQuestionId());
+        QuestionDetailDto questionDetailDto = questionService.getQuestion(userId, request.getQuestionId());
 
         UserAnswerContext context = new UserAnswerContext(userId, request.getQuestionId());
 

--- a/src/main/java/com/upstage/devup/web/QuestionController.java
+++ b/src/main/java/com/upstage/devup/web/QuestionController.java
@@ -1,9 +1,11 @@
 package com.upstage.devup.web;
 
+import com.upstage.devup.auth.config.AuthenticatedUser;
 import com.upstage.devup.question.dto.QuestionDetailDto;
 import com.upstage.devup.question.service.QuestionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -45,14 +47,27 @@ public class QuestionController {
             startPage = Math.max(0, endPage - pageBlockSize);
         }
 
-        List<Integer> pageNumbers = IntStream.range(startPage, endPage).boxed().toList();
-        return pageNumbers;
+        return IntStream.range(startPage, endPage).boxed().toList();
     }
 
+    /**
+     * 면접 질문 상세 페이지 불러오기
+     *
+     * @param user       사용자 정보
+     * @param questionId 면접 질문 ID
+     * @param model      페이지로 전달할 정보
+     * @return 면접 질문 상세 페이지
+     */
     @GetMapping("/{questionId}")
-    public String getQuestionDetailView(@PathVariable Long questionId, Model model) {
-        QuestionDetailDto question = questionService.getQuestion(questionId);
-        model.addAttribute("question", question);
+    public String getQuestionDetailView(
+            @AuthenticationPrincipal AuthenticatedUser user,
+            @PathVariable Long questionId,
+            Model model
+    ) {
+        long userId = user == null ? 0L : user.getUserId();
+        QuestionDetailDto result = questionService.getQuestion(userId, questionId);
+
+        model.addAttribute("question", result);
 
         return "question/question-detail";
     }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -10,10 +10,9 @@ CREATE TABLE answers
 
 CREATE TABLE bookmarks
 (
-    id          BIGINT NOT NULL AUTO_INCREMENT,
     user_id     BIGINT NOT NULL,
     question_id BIGINT NOT NULL,
-    PRIMARY KEY (id)
+    PRIMARY KEY (user_id, question_id)
 ); -- '북마크'
 
 CREATE TABLE categories

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -10,8 +10,9 @@ CREATE TABLE answers
 
 CREATE TABLE bookmarks
 (
-    user_id     BIGINT NOT NULL,
-    question_id BIGINT NOT NULL,
+    user_id     BIGINT      NOT NULL,
+    question_id BIGINT      NOT NULL,
+    created_at  TIMESTAMP   NOT NULL    DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (user_id, question_id)
 ); -- '북마크'
 

--- a/src/main/resources/static/css/question/question-detail.css
+++ b/src/main/resources/static/css/question/question-detail.css
@@ -66,17 +66,33 @@ main {
     margin-bottom: 0.5rem;
 }
 
-.meta {
+.question-header-body {
+    display: flex;
+    justify-content: space-between;
+}
+
+.question-header-body span {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+
+.meta-left, .meta-right {
     font-size: 0.95rem;
     color: #555;
     display: flex;
     gap: 1.5rem;
 }
 
-.meta span {
-    display: flex;
-    align-items: center;
-    gap: 0.4rem;
+.meta-right {
+    justify-content: flex-end;
+}
+
+.meta-right button {
+    border: none;
+    background: none;
+    color: #555;
+    cursor: pointer;
 }
 
 .question-body, .answer-body {

--- a/src/main/resources/static/js/question/question-detail.js
+++ b/src/main/resources/static/js/question/question-detail.js
@@ -1,15 +1,54 @@
-const toggleBtn = document.getElementById("toggle-answer-btn");
 const answerBox = document.getElementById("answer-box");
 const answerText = document.getElementById("answer-text");
-
-const correctBtn = document.getElementById("correct-btn");
-const wrongBtn = document.getElementById("wrong-btn");
 const userAnswerBox = document.getElementById("user-answer");
 
+const questionId = document.getElementById("container").dataset.questionId;
+
+const toggleBtn = document.getElementById("toggle-answer-btn");
 toggleBtn.addEventListener("click", handleAnswerToggle);
 
+const correctBtn = document.getElementById("correct-btn");
 correctBtn.addEventListener("click", () => send(true));
+
+const wrongBtn = document.getElementById("wrong-btn");
 wrongBtn.addEventListener("click", () => send(false));
+
+const bookmarkBtn = document.getElementById("bookmark-btn");
+bookmarkBtn.addEventListener('click', () => toggleBookmark(bookmarkBtn));
+
+async function toggleBookmark(button) {
+    const isBookmarked = button.classList.contains('bookmarked');
+
+    try {
+        const response = await fetch(`/api/bookmarks/${questionId}`, {
+            method: isBookmarked ? 'DELETE' : 'POST'
+        });
+
+        switch (response.status) {
+            case 200: {
+                confirm(isBookmarked ? '북마크를 삭제했습니다.' : '북마크를 저장했습니다.');
+
+                button.classList.toggle('bookmarked');
+                button.innerText = isBookmarked ? '🔖 북마크 추가' : '❌ 북마크 삭제';
+
+                break;
+            }
+            case 401: {
+                const confirmed = confirm('로그인이 필요합니다.\n[확인]을 누르면 로그인 화면으로 이동합니다.');
+                if (confirmed) {
+                    window.location.href="/auth/signin";
+                }
+                break;
+            }
+            default: {
+                console.log(response.status);
+                alert('알 수 없는 에러가 발생했습니다.');
+            }
+        }
+    } catch (err) {
+        alert(err);
+    }
+}
 
 async function handleAnswerToggle() {
     const isAnswerShown = toggleAnswerBox();
@@ -35,7 +74,6 @@ async function fetchAndShowAnswer() {
     try {
         answerText.textContent = '정답을 불러오는 중입니다.';
 
-        const questionId = document.getElementById("container").dataset.questionId;
         const res = await fetch('/api/answers/' + questionId);
         const data = await res.json();
 
@@ -60,7 +98,7 @@ async function send(isCorrect) {
                 'Content-Type': 'application/json'
             },
             body: JSON.stringify({
-                'questionId': document.getElementById('container').dataset.questionId,
+                'questionId': questionId,
                 'answerText': userAnswer,
                 'isCorrect': isCorrect
             })

--- a/src/main/resources/static/js/user/mypage/mypage-bookmarks.js
+++ b/src/main/resources/static/js/user/mypage/mypage-bookmarks.js
@@ -1,0 +1,127 @@
+import {formatDate, getPageNumbers} from "/js/util/util.js";
+
+/**
+ * 북마크 목록 보여주기
+ *
+ * @param pageNumber 페이지 번호
+ * @returns {Promise<void>}
+ */
+export async function showBookmarks(pageNumber) {
+    try {
+        const tbody = document.getElementById('bookmark-body');
+        const paginationEl = document.getElementById('bookmark-pagination');
+        tbody.innerHTML = '';
+        paginationEl.innerHTML = '';
+
+        const data = await fetchBookmarks(pageNumber);
+
+        // 북마크 목록 보여주기
+        renderBookmarkTable(data, tbody);
+
+        // 페이징 처리
+        renderPagination(data, paginationEl);
+
+        // 삭제 버튼에 이벤트 할당
+        addDeleteButtonClickHandler();
+    } catch (err) {
+        alert(err);
+    }
+}
+
+/**
+ * 서버에 오답노트 데이터 요청하기
+ *
+ * @param pageNumber 페이지 번호
+ * @returns {Promise<any>}
+ */
+async function fetchBookmarks(pageNumber) {
+    const url = '/api/bookmarks?pageNumber=' + pageNumber;
+    const response = await fetch(url, {
+        method: "GET"
+    });
+
+    if (!response.ok) {
+        throw new Error('오답노트를 불러오는 데 실패했습니다.');
+    }
+
+    return await response.json();
+}
+
+/**
+ * 오답노트 테이블 렌더링
+ *
+ * @param data 서버에서 받은 오답노트 데이터
+ * @param tbody 테이블 tbody 요소
+ */
+function renderBookmarkTable(data, tbody) {
+    data.contents.forEach(item => {
+        const row = document.createElement('tr');
+        row.innerHTML = `
+                <td>${item.questionId}</td>
+                <td><a href="/questions/${item.questionId}">${item.title}</a></td>
+                <td>${item.category}</td>
+                <td>${item.level}</td>
+                <td>${formatDate(item.createdAt)}</td>
+                <td>
+                    <button class="delete-btn" data-question-id="${item.questionId}">
+                        <span>삭제</span>
+                    </button>
+                </td>
+            `;
+
+        tbody.appendChild(row);
+    })
+}
+
+/**
+ * 오답노트 페이징 처리
+ *
+ * @param data 오답노트 데이터
+ * @param paginationEl
+ */
+function renderPagination(data, paginationEl) {
+    const pageNumbers = getPageNumbers(data.currentPageNumber, data.totalPages);
+
+    pageNumbers.forEach(page => {
+        const btn = document.createElement("button");
+        btn.textContent = page + 1;
+
+        if (page === data.currentPageNumber) {
+            btn.classList.add("active");
+            btn.disabled = true;
+        }
+
+        btn.addEventListener("click", () => showBookmarks(page));
+
+        paginationEl.appendChild(btn);
+    });
+}
+
+/**
+ * [삭제] 버튼에 이벤트 할당하기
+ */
+function addDeleteButtonClickHandler() {
+    const buttons = document.querySelectorAll(".delete-btn");
+
+    buttons.forEach(button => {
+        const questionId = button.getAttribute('data-question-id');
+        button.addEventListener('click', () => deleteBookmark(questionId));
+    })
+}
+
+async function deleteBookmark(questionId) {
+    try {
+        const response = await fetch(`/api/bookmarks/${questionId}`, {
+            method: 'DELETE'
+        });
+
+        if (response.ok) {
+            confirm('북마크를 삭제했습니다.');
+            await showBookmarks(0);
+        } else {
+            alert('북마크를 삭제할 수 없습니다.');
+        }
+    } catch (err) {
+        alert(err);
+    }
+}

--- a/src/main/resources/static/js/user/mypage/mypage.js
+++ b/src/main/resources/static/js/user/mypage/mypage.js
@@ -1,5 +1,6 @@
 import {showProfile} from '/js/user/mypage/mypage-profile.js';
 import {showWrongNote} from '/js/user/mypage/mypage-wrong-note.js';
+import {showBookmarks} from '/js/user/mypage/mypage-bookmarks.js';
 
 const tabContainer = document.getElementById('tab-container');
 const buttons = document.querySelectorAll(".tab-button");
@@ -9,6 +10,7 @@ const tabActionMap = {
     stats: () => {},
     history: () => showUserSolvedQuestions(0),
     wrong: () => showWrongNote(0),
+    bookmarks: () => showBookmarks(0),
     profile: showProfile
 };
 

--- a/src/main/resources/templates/question/question-detail.html
+++ b/src/main/resources/templates/question/question-detail.html
@@ -26,10 +26,17 @@
 
         <div class="question-header">
             <h1>📋 Java의 정적(static) 키워드란?</h1>
-            <div class="meta">
-                <span>📁 Java</span>
-                <span>🎯 중</span>
-                <span>🕒 2025-05-09</span>
+            <div class="question-header-body">
+                <div class="meta-left">
+                    <span>📁 Java</span>
+                    <span>🎯 중</span>
+                    <span>🕒 2025-05-09</span>
+                </div>
+                <div class="meta-right">
+                    <button id="bookmark-btn">
+                        <span>🔖 북마크 추가</span>
+                    </button>
+                </div>
             </div>
         </div>
 

--- a/src/main/resources/templates/question/question-detail.th.xml
+++ b/src/main/resources/templates/question/question-detail.th.xml
@@ -13,11 +13,16 @@
         </attr>
         <attr sel="div.question-header">
             <attr sel="h1" th:text="'📋 ' + ${question.title}"/>
-            <attr sel="div.meta">
+            <attr sel="div.meta-left">
                 <attr sel="span[0]" th:text="'📁 ' + ${question.category}"/>
                 <attr sel="span[1]" th:text="'🎯 ' + ${question.level}"/>
                 <attr sel="span[2]" th:datetime="${question.createdAt}"
                       th:text="'🕒 ' + ${#temporals.format(question.createdAt, 'yyyy-MM-dd')}"/>
+            </attr>
+            <attr sel="div.meta-right">
+                <attr sel="#bookmark-btn" th:class="${question.isBookmarked ? 'bookmarked' : ''}">
+                    <attr sel="span" th:text="${question.isBookmarked ? '❌ 북마크 삭제' : '🔖 북마크 추가'}"/>
+                </attr>
             </attr>
         </attr>
         <attr sel="div.question-body" th:text="${question.questionText}"/>

--- a/src/main/resources/templates/user/mypage/mypage.html
+++ b/src/main/resources/templates/user/mypage/mypage.html
@@ -27,6 +27,7 @@
         <button class="tab-button active" data-tab="stats" id="stats-tab-btn">📈 통계</button>
         <button class="tab-button" data-tab="history">🕓 풀이 이력</button>
         <button class="tab-button" data-tab="wrong">❌ 오답 노트</button>
+        <button class="tab-button" data-tab="bookmarks">🔖 북마크</button>
         <button class="tab-button" data-tab="profile">🙋 사용자 정보</button>
     </div>
     <div id="tab-container">
@@ -114,6 +115,43 @@
         </tbody>
     </table>
     <div class="pagination" id="wrong-pagination">
+        <button class="active">1</button>
+        <button>2</button>
+        <button>3</button>
+    </div>
+</template>
+<template class="tab-content" id="bookmarks">
+    <table>
+        <thead>
+        <tr>
+            <th>No.</th>
+            <th>제목</th>
+            <th>카테고리</th>
+            <th>난이도</th>
+            <th>등록일</th>
+            <th>삭제</th>
+        </tr>
+        </thead>
+        <tbody id="bookmark-body">
+        <tr>
+            <td>2</td>
+            <td>SQL JOIN 종류</td>
+            <td>DB</td>
+            <td>상</td>
+            <td>2025-05-08</td>
+            <td><button class="delete-btn" disabled><span>삭제</span></button></td>
+        </tr>
+        <tr>
+            <td>1</td>
+            <td>OOP란?</td>
+            <td>JAVA</td>
+            <td>하</td>
+            <td>2025-05-08</td>
+            <td><button class="delete-btn"><span>삭제</span></button></td>
+        </tr>
+        </tbody>
+    </table>
+    <div class="pagination" id="bookmark-pagination">
         <button class="active">1</button>
         <button>2</button>
         <button>3</button>

--- a/src/test/java/com/upstage/devup/bookmark/controller/BookmarkControllerTest.java
+++ b/src/test/java/com/upstage/devup/bookmark/controller/BookmarkControllerTest.java
@@ -12,12 +12,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
-import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -25,6 +25,7 @@ import java.time.temporal.ChronoUnit;
 
 import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -119,11 +120,89 @@ class BookmarkControllerTest {
                 // when & then
                 mockMvc.perform(post(URL_TEMPLATE + questionId)
                                 .with(getAuthentication(userId)))
-                        .andDo(MockMvcResultHandlers.print())
                         .andExpect(status().isNotFound());
             }
         }
 
     }
 
+    @Nested
+    @DisplayName("북마크 삭제")
+    public class BookmarkDeletion {
+
+        private static final String URL_TEMPLATE = "/api/bookmarks/";
+
+        @Nested
+        @DisplayName("성공 케이스")
+        public class SuccessCases {
+
+            @Test
+            @DisplayName("유효한 userId, questionId를 사용한 경우 - 저장된 북마크 삭제")
+            public void shouldReturn200_whenUserIdAndQuestionIdAreValid() throws Exception {
+                // given
+                long userId = 1L;
+                long questionId = 2L;
+                LocalDateTime now = LocalDateTime.now();
+
+                BookmarkResponseDto mockResult = BookmarkResponseDto.builder()
+                        .userId(userId)
+                        .questionId(questionId)
+                        .createdAt(now)
+                        .build();
+
+                when(bookmarkService.deleteBookmark(eq(userId), eq(questionId)))
+                        .thenReturn(mockResult);
+
+                // when & then
+                String expectedCreatedAt = now
+                        .truncatedTo(ChronoUnit.SECONDS)
+                        .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+
+                mockMvc.perform(delete(URL_TEMPLATE + questionId)
+                                .with(getAuthentication(userId)))
+                        .andExpect(status().isOk())
+                        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                        .andExpect(jsonPath("$.userId").value(userId))
+                        .andExpect(jsonPath("$.questionId").value(questionId))
+                        .andExpect(jsonPath("$.createdAt").value(expectedCreatedAt));
+            }
+        }
+
+        @Nested
+        @DisplayName("실패 케이스")
+        public class FailureCases {
+
+            @Test
+            @DisplayName("로그인을 하지 않은 경우 401 Unauthorized 응답")
+            public void shouldReturn401_whenUserDoesNotSignIn() throws Exception {
+                // given
+                long questionId = 1L;
+
+                // when & then
+                mockMvc.perform(post(URL_TEMPLATE + questionId))
+                        .andExpect(status().isUnauthorized());
+            }
+
+            @Test
+            @DisplayName("DB에 저장된 북마크가 없는 경우 - EntityNotFoundException 예외 발생")
+            public void shouldReturn404_whenBookmarkDoesNotExistsInDB() throws Exception {
+                // given
+                long userId = 1L;
+                long questionId = Long.MAX_VALUE;
+
+                doThrow(new EntityNotFoundException("존재하지 않는 북마크입니다."))
+                        .when(bookmarkService)
+                        .deleteBookmark(userId, questionId);
+
+                // when & then
+                mockMvc.perform(delete(URL_TEMPLATE + questionId)
+                                .with(getAuthentication(userId)))
+                        .andExpect(status().isNotFound())
+                        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                        .andExpect(jsonPath("$.code").value("NOT_FOUND"))
+                        .andExpect(jsonPath("$.message").value("존재하지 않는 북마크입니다."));
+
+            }
+        }
+    }
 }

--- a/src/test/java/com/upstage/devup/bookmark/controller/BookmarkControllerTest.java
+++ b/src/test/java/com/upstage/devup/bookmark/controller/BookmarkControllerTest.java
@@ -3,7 +3,9 @@ package com.upstage.devup.bookmark.controller;
 import com.upstage.devup.auth.config.AuthenticatedUser;
 import com.upstage.devup.auth.config.SecurityConfig;
 import com.upstage.devup.auth.config.jwt.JwtTokenProvider;
+import com.upstage.devup.bookmark.dto.BookmarkDetails;
 import com.upstage.devup.bookmark.dto.BookmarkResponseDto;
+import com.upstage.devup.bookmark.dto.BookmarksQueryDto;
 import com.upstage.devup.bookmark.service.BookmarkService;
 import com.upstage.devup.global.exception.EntityNotFoundException;
 import org.junit.jupiter.api.DisplayName;
@@ -12,6 +14,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -22,11 +26,12 @@ import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(BookmarkController.class)
@@ -46,6 +51,115 @@ class BookmarkControllerTest {
         AuthenticatedUser user = new AuthenticatedUser(userId);
         Authentication auth = new UsernamePasswordAuthenticationToken(user, null, null);
         return authentication(auth);
+    }
+
+    @Nested
+    @DisplayName("북마크 조회")
+    public class BookmarkQuery {
+
+        @Nested
+        @DisplayName("성공 케이스")
+        public class SuccessCases {
+
+            private static final String URL_TEMPLATE = "/api/bookmarks";
+            BookmarksQueryDto mockResult = new BookmarksQueryDto(new PageImpl<>(List.of(
+                    new BookmarkDetails(1L, "제목1", "카테고리1", "난이도1", LocalDateTime.now()),
+                    new BookmarkDetails(2L, "제목2", "카테고리2", "난이도2", LocalDateTime.now()),
+                    new BookmarkDetails(3L, "제목3", "카테고리3", "난이도3", LocalDateTime.now()),
+                    new BookmarkDetails(4L, "제목4", "카테고리4", "난이도4", LocalDateTime.now()),
+                    new BookmarkDetails(5L, "제목5", "카테고리5", "난이도5", LocalDateTime.now()),
+                    new BookmarkDetails(6L, "제목6", "카테고리6", "난이도6", LocalDateTime.now()),
+                    new BookmarkDetails(7L, "제목7", "카테고리7", "난이도7", LocalDateTime.now()),
+                    new BookmarkDetails(8L, "제목8", "카테고리8", "난이도8", LocalDateTime.now()),
+                    new BookmarkDetails(9L, "제목9", "카테고리9", "난이도9", LocalDateTime.now()),
+                    new BookmarkDetails(10L, "제목10", "카테고리10", "난이도10", LocalDateTime.now())
+            )));
+
+            @Test
+            @DisplayName("유효한 사용자 ID, pageNumber를 사용한 경우 - 북마크 목록을 반환")
+            public void shouldReturn200_whenRequestIdValid() throws Exception {
+                // given
+                long userId = 1L;
+                int pageNumber = 0;
+
+                when(bookmarkService.getBookmarks(eq(userId), eq(pageNumber)))
+                        .thenReturn(mockResult);
+
+                // when & then
+                mockMvc.perform(get(URL_TEMPLATE)
+                                .with(getAuthentication(userId))
+                                .param("pageNumber", String.valueOf(pageNumber)))
+                        .andExpect(status().isOk())
+                        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                        .andExpect(jsonPath("$.contents.size()").value(10))
+                        .andExpect(jsonPath("$.contents[0].questionId").value(1L))
+                        .andExpect(jsonPath("$.contents[0].title").value("제목1"))
+                        .andExpect(jsonPath("$.contents[0].category").value("카테고리1"))
+                        .andExpect(jsonPath("$.contents[0].level").value("난이도1"))
+                        .andExpect(jsonPath("$.currentPageNumber").value(0))
+                        .andExpect(jsonPath("$.size").value(10))
+                        .andExpect(jsonPath("$.totalPages").value(1))
+                        .andExpect(jsonPath("$.totalElements").value(10))
+                        .andExpect(jsonPath("$.hasPrevious").value(false))
+                        .andExpect(jsonPath("$.hasNext").value(false));
+            }
+
+            @Test
+            @DisplayName("pageNumber가 음수인 경우 - pageNumber가 0으로 조회된 결과를 반환")
+            public void shouldReturn200_whenPageNumberIsNegative() throws Exception {
+                // given
+                long userId = 1L;
+                int pageNumber = -1;
+
+                when(bookmarkService.getBookmarks(eq(userId), eq(pageNumber)))
+                        .thenReturn(mockResult);
+
+                // when & then
+                mockMvc.perform(get(URL_TEMPLATE)
+                                .with(getAuthentication(userId))
+                                .param("pageNumber", String.valueOf(pageNumber)))
+                        .andExpect(status().isOk())
+                        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                        .andExpect(jsonPath("$.contents.size()").value(10))
+                        .andExpect(jsonPath("$.contents[0].questionId").value(1L))
+                        .andExpect(jsonPath("$.contents[0].title").value("제목1"))
+                        .andExpect(jsonPath("$.contents[0].category").value("카테고리1"))
+                        .andExpect(jsonPath("$.contents[0].level").value("난이도1"))
+                        .andExpect(jsonPath("$.currentPageNumber").value(0))
+                        .andExpect(jsonPath("$.size").value(10))
+                        .andExpect(jsonPath("$.totalPages").value(1))
+                        .andExpect(jsonPath("$.totalElements").value(10))
+                        .andExpect(jsonPath("$.hasPrevious").value(false))
+                        .andExpect(jsonPath("$.hasNext").value(false));
+            }
+
+            @Test
+            @DisplayName("존재하지 않는 사용자 ID로 조회하는 경우 - 빈 값을 반환")
+            public void shouldReturn200_whenUserIdIsUnavailable() throws Exception {
+                // given
+                long userId = -1L;
+                int pageNumber = 0;
+
+                when(bookmarkService.getBookmarks(eq(userId), eq(pageNumber)))
+                        .thenReturn(new BookmarksQueryDto(
+                                new PageImpl<>(List.of(), PageRequest.of(pageNumber, 10), 0)
+                        ));
+
+                // when & then
+                mockMvc.perform(get(URL_TEMPLATE)
+                                .with(getAuthentication(userId))
+                                .param("pageNumber", String.valueOf(pageNumber)))
+                        .andExpect(status().isOk())
+                        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                        .andExpect(jsonPath("$.contents.size()").value(0))
+                        .andExpect(jsonPath("$.currentPageNumber").value(0))
+                        .andExpect(jsonPath("$.size").value(10))
+                        .andExpect(jsonPath("$.totalPages").value(0))
+                        .andExpect(jsonPath("$.totalElements").value(0))
+                        .andExpect(jsonPath("$.hasPrevious").value(false))
+                        .andExpect(jsonPath("$.hasNext").value(false));
+            }
+        }
     }
 
     @Nested

--- a/src/test/java/com/upstage/devup/bookmark/controller/BookmarkControllerTest.java
+++ b/src/test/java/com/upstage/devup/bookmark/controller/BookmarkControllerTest.java
@@ -26,7 +26,6 @@ import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.mockito.Mockito.*;

--- a/src/test/java/com/upstage/devup/bookmark/controller/BookmarkControllerTest.java
+++ b/src/test/java/com/upstage/devup/bookmark/controller/BookmarkControllerTest.java
@@ -1,0 +1,129 @@
+package com.upstage.devup.bookmark.controller;
+
+import com.upstage.devup.auth.config.AuthenticatedUser;
+import com.upstage.devup.auth.config.SecurityConfig;
+import com.upstage.devup.auth.config.jwt.JwtTokenProvider;
+import com.upstage.devup.bookmark.dto.BookmarkResponseDto;
+import com.upstage.devup.bookmark.service.BookmarkService;
+import com.upstage.devup.global.exception.EntityNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(BookmarkController.class)
+@Import(SecurityConfig.class)
+class BookmarkControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private BookmarkService bookmarkService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    private RequestPostProcessor getAuthentication(Long userId) {
+        AuthenticatedUser user = new AuthenticatedUser(userId);
+        Authentication auth = new UsernamePasswordAuthenticationToken(user, null, null);
+        return authentication(auth);
+    }
+
+    @Nested
+    @DisplayName("신규 북마크 등록")
+    public class BookmarkRegistration {
+
+        private static final String URL_TEMPLATE = "/api/bookmarks/";
+
+        @Nested
+        @DisplayName("성공 케이스")
+        public class SuccessCases {
+
+            @Test
+            @DisplayName("유효한 userId와 questionId를 사용한 경우")
+            public void shouldReturn200_whenUserIdAndQuestionIdAreValid() throws Exception {
+                // given
+                Long userId = 1L;
+                Long questionId = 2L;
+                LocalDateTime now = LocalDateTime.now();
+
+                BookmarkResponseDto mockResult = BookmarkResponseDto.builder()
+                        .userId(userId)
+                        .questionId(questionId)
+                        .createdAt(now)
+                        .build();
+
+                when(bookmarkService.registerBookmark(eq(userId), eq(questionId)))
+                        .thenReturn(mockResult);
+
+                // when & then
+                String expectedCreatedAt = now
+                        .truncatedTo(ChronoUnit.SECONDS)
+                        .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+
+                mockMvc.perform(
+                                post(URL_TEMPLATE + questionId)
+                                        .with(getAuthentication(userId)))
+                        .andExpect(status().isOk())
+                        .andExpect(content().contentType("application/json"))
+                        .andExpect(jsonPath("$.userId").value(userId))
+                        .andExpect(jsonPath("$.questionId").value(questionId))
+                        .andExpect(jsonPath("$.createdAt").value(expectedCreatedAt));
+            }
+        }
+
+        @Nested
+        @DisplayName("실패 케이스")
+        public class FailureCases {
+
+            @Test
+            @DisplayName("로그인을 하지 않은 경우 401 Unauthorized 응답")
+            public void shouldReturn401_whenUserDoesNotSignIn() throws Exception {
+                // given
+                long questionId = 1L;
+
+                // when & then
+                mockMvc.perform(post(URL_TEMPLATE + questionId))
+                        .andExpect(status().isUnauthorized());
+            }
+
+            @Test
+            @DisplayName("유효한 질문 ID가 아닌 경우 404 Not Found 응답")
+            public void shouldReturn404_whenQuestionDoesNotExistInDB() throws Exception {
+                // given
+                long userId = 1L;
+                long questionId = -1L;
+
+                doThrow(new EntityNotFoundException("존재하지 않는 질문입니다."))
+                        .when(bookmarkService)
+                        .registerBookmark(userId, questionId);
+
+                // when & then
+                mockMvc.perform(post(URL_TEMPLATE + questionId)
+                                .with(getAuthentication(userId)))
+                        .andDo(MockMvcResultHandlers.print())
+                        .andExpect(status().isNotFound());
+            }
+        }
+
+    }
+
+}

--- a/src/test/java/com/upstage/devup/bookmark/service/BookmarkServiceTest.java
+++ b/src/test/java/com/upstage/devup/bookmark/service/BookmarkServiceTest.java
@@ -69,8 +69,6 @@ class BookmarkServiceTest {
     public class BookmarksQuery {
 
         private final int totalElements = 12;
-        private final int pageSize = 10;
-
         @BeforeEach
         public void beforeEach() {
             User user = userAccountRepository.findById(userId)

--- a/src/test/java/com/upstage/devup/bookmark/service/BookmarkServiceTest.java
+++ b/src/test/java/com/upstage/devup/bookmark/service/BookmarkServiceTest.java
@@ -1,0 +1,191 @@
+package com.upstage.devup.bookmark.service;
+
+import com.upstage.devup.bookmark.dto.BookmarkResponseDto;
+import com.upstage.devup.bookmark.repository.BookmarkRepository;
+import com.upstage.devup.global.domain.id.BookmarkId;
+import com.upstage.devup.global.entity.*;
+import com.upstage.devup.global.exception.EntityNotFoundException;
+import com.upstage.devup.question.repository.QuestionRepository;
+import com.upstage.devup.user.account.repository.UserAccountRepository;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@SpringBootTest
+@Transactional
+class BookmarkServiceTest {
+
+    @Autowired
+    private BookmarkService bookmarkService;
+
+    @Autowired
+    private BookmarkRepository bookmarkRepository;
+
+    @Autowired
+    private UserAccountRepository userAccountRepository;
+
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    private Long userId;
+    private Long questinId;
+
+    @BeforeEach
+    public void beforeEach() {
+        User user = userAccountRepository.save(User.builder()
+                .loginId("user1234")
+                .password("pass1234")
+                .nickname("nickname1234")
+                .email("user1234@gmail.com")
+                .createdAt(LocalDateTime.now())
+                .build());
+
+        Question question = questionRepository.save(Question.builder()
+                .title("제목 1")
+                .questionText("질문 내용")
+                .category(Category.builder().id(1L).build())
+                .level(Level.builder().id(2L).build())
+                .createdAt(LocalDateTime.now())
+                .build());
+
+        this.userId = user.getId();
+        this.questinId = question.getId();
+    }
+
+    @Nested
+    @DisplayName("북마크 등록 기능 테스트")
+    public class BookmarkRegistration {
+
+        @Nested
+        @DisplayName("북마크 등록 성공")
+        public class SuccessCases {
+
+            @Test
+            @DisplayName("userId와 questionId가 유효한 값이면 성공")
+            public void shouldReturnBookmarkResponseDto_whenUserIdAndQuestionIdAreValid() {
+                // given
+
+                // when
+                BookmarkResponseDto result = bookmarkService.registerBookmark(userId, questinId);
+
+                // then
+                assertThat(result).isNotNull();
+                assertThat(result.getUserId()).isEqualTo(userId);
+                assertThat(result.getQuestionId()).isEqualTo(questinId);
+                assertThat(result.getCreatedAt()).isNotNull();
+                assertThat(result.getCreatedAt()).isBefore(LocalDateTime.now());
+            }
+
+            @Test
+            @DisplayName("이미 저장된 북마크가 있는 경우 정상 등록 처리")
+            public void shouldReturnBookmarkResponseDto_whenUserIdAndQuestionIdAreAlreadyUsed() {
+                // given
+                Bookmark entity = bookmarkRepository.save(
+                        Bookmark.builder()
+                                .id(new BookmarkId(userId, questinId))
+                                .user(User.builder().id(userId).build())
+                                .question(Question.builder().id(questinId).build())
+                                .createdAt(LocalDateTime.now())
+                                .build()
+                );
+
+                // when
+                BookmarkResponseDto result = bookmarkService.registerBookmark(userId, questinId);
+
+                // then
+                assertThat(result).isNotNull();
+                assertThat(result.getUserId()).isEqualTo(userId);
+                assertThat(result.getQuestionId()).isEqualTo(questinId);
+                assertThat(result.getCreatedAt()).isEqualTo(entity.getCreatedAt());
+            }
+        }
+
+        @Nested
+        @DisplayName("북마크 등록 실패")
+        public class FailureCases {
+
+            @Test
+            @DisplayName("유효하지 않은 userId(0)를 사용한 경우")
+            public void shouldThrowEntityNotFoundException_whenUserIdIsZero() {
+                // given
+                long wrongUserId = 0L;
+
+                // when
+                EntityNotFoundException exception = assertThrows(
+                        EntityNotFoundException.class,
+                        () -> bookmarkService.registerBookmark(wrongUserId, questinId)
+                );
+
+                assertThat(exception.getMessage()).isEqualTo("존재하지 않는 회원입니다.");
+            }
+
+            @Test
+            @DisplayName("유효하지 않은 userId(음수)를 사용한 경우")
+            public void shouldThrowEntityNotFoundException_whenUserIdIsNegative() {
+                // given
+                long wrongUserId = -1L;
+
+                // when
+                EntityNotFoundException exception = assertThrows(
+                        EntityNotFoundException.class,
+                        () -> bookmarkService.registerBookmark(wrongUserId, questinId)
+                );
+
+                assertThat(exception.getMessage()).isEqualTo("존재하지 않는 회원입니다.");
+            }
+
+            @Test
+            @DisplayName("유효하지 않은 questionId(0)를 사용한 경우")
+            public void shouldThrowEntityNotFoundException_whenQuestionIdIsZero() {
+                // given
+                long wrongQuestionId = 0L;
+
+                // when
+                EntityNotFoundException exception = assertThrows(
+                        EntityNotFoundException.class,
+                        () -> bookmarkService.registerBookmark(userId, wrongQuestionId)
+                );
+
+                assertThat(exception.getMessage()).isEqualTo("존재하지 않는 질문입니다.");
+            }
+
+            @Test
+            @DisplayName("유효하지 않은 questionId(음수)를 사용한 경우")
+            public void shouldThrowEntityNotFoundException_whenQuestionIdIsNegative() {
+                // given
+                long wrongQuestionId = -1L;
+
+                // when
+                EntityNotFoundException exception = assertThrows(
+                        EntityNotFoundException.class,
+                        () -> bookmarkService.registerBookmark(userId, wrongQuestionId)
+                );
+
+                assertThat(exception.getMessage()).isEqualTo("존재하지 않는 질문입니다.");
+            }
+
+            @Test
+            @DisplayName("유효하지 않은 userId와 questionId를 사용한 경우")
+            public void shouldThrowEntityNotFoundException_whenUserIdAndQuestionIdAreUnavailable() {
+                // given
+                long wrongUserId = -1L;
+                long wrongQuestionId = 0L;
+
+                // when
+                EntityNotFoundException exception = assertThrows(
+                        EntityNotFoundException.class,
+                        () -> bookmarkService.registerBookmark(wrongUserId, wrongQuestionId)
+                );
+
+                assertThat(exception.getMessage()).isEqualTo("존재하지 않는 회원입니다.");
+            }
+        }
+    }
+}

--- a/src/test/java/com/upstage/devup/question/controller/QuestionQueryControllerTest.java
+++ b/src/test/java/com/upstage/devup/question/controller/QuestionQueryControllerTest.java
@@ -17,7 +17,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -25,14 +24,11 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import static org.hamcrest.Matchers.nullValue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@Nested
 @WebMvcTest(QuestionQueryController.class)
 @Import(SecurityConfig.class)
 @DisplayName("면접 질문 제목 검색 테스트")

--- a/src/test/java/com/upstage/devup/question/service/QuestionServiceTest.java
+++ b/src/test/java/com/upstage/devup/question/service/QuestionServiceTest.java
@@ -1,107 +1,249 @@
 package com.upstage.devup.question.service;
 
+import com.upstage.devup.bookmark.repository.BookmarkRepository;
+import com.upstage.devup.global.domain.id.BookmarkId;
+import com.upstage.devup.global.entity.*;
 import com.upstage.devup.global.exception.EntityNotFoundException;
 import com.upstage.devup.question.dto.QuestionDetailDto;
+import com.upstage.devup.question.repository.QuestionRepository;
+import com.upstage.devup.user.account.repository.UserAccountRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
+@Transactional
 class QuestionServiceTest {
 
     @Autowired
     private QuestionService questionService;
 
-    @Transactional
-    @Test
-    @DisplayName("면접 질문 페이지 조회 - 성공")
-    public void successGetQuestions() {
-        // given
-        int page = 0;
+    @Autowired
+    private UserAccountRepository userAccountRepository;
 
-        // when
-        Page<QuestionDetailDto> questions = questionService.getQuestions(page);
+    @Autowired
+    private QuestionRepository questionRepository;
 
-        // then
-        assertThat(questions.getContent().size()).isEqualTo(10);
+    @Autowired
+    private BookmarkRepository bookmarkRepository;
+
+    @Nested
+    @DisplayName("면접 질문 페이지 조회")
+    public class QuestionPagingQuery {
+
+        @Test
+        @DisplayName("면접 질문 페이지 조회 - 성공")
+        public void successGetQuestions() {
+            // given
+            int page = 0;
+
+            // when
+            Page<QuestionDetailDto> questions = questionService.getQuestions(page);
+
+            // then
+            assertThat(questions.getContent().size()).isEqualTo(10);
+        }
     }
 
-    @Transactional
-    @Test
-    @DisplayName("제목 검색 - 성공")
-    public void successToSearchQuestionByTitle() {
-        // given
-        String title = "Spring";
-        int page = 0;
+    @Nested
+    @DisplayName("면접 질문 제목 검색")
+    public class QuestionSearch {
 
-        // when
-        Page<QuestionDetailDto> results = questionService.searchQuestionsByTitle(title, page);
+        @Nested
+        @DisplayName("성공 케이스")
+        public class SuccessCases {
 
-        // then
-        assertThat(results.getTotalElements()).isGreaterThan(0);
+            @Test
+            @DisplayName("제목 검색 - 성공")
+            public void successToSearchQuestionByTitle() {
+                // given
+                String title = "Spring";
+                int page = 0;
+
+                // when
+                Page<QuestionDetailDto> results = questionService.searchQuestionsByTitle(title, page);
+
+                // then
+                assertThat(results.getTotalElements()).isGreaterThan(0);
+            }
+        }
+
+        @Nested
+        @DisplayName("실패 케이스")
+        public class FailureCases {
+
+            @Test
+            @DisplayName("검색어가 공백인 경우 - 빈 값을 반환")
+            public void failToSearchQuestionByTitleUsingSpace() {
+                // given
+                String title = "     ";
+                int page = 0;
+
+                // when
+                Page<QuestionDetailDto> results = questionService.searchQuestionsByTitle(title, page);
+
+                // then
+                assertThat(results.getTotalElements()).isEqualTo(0);
+            }
+
+            @Test
+            @DisplayName("검색어의 길이가 2보다 작을 경우 - 빈 값을 반환")
+            public void failToSearchQuestionByTitleUsingShortTitle() {
+                // given
+                String title = "1";
+                int page = 0;
+
+                // when
+                Page<QuestionDetailDto> results = questionService.searchQuestionsByTitle(title, page);
+
+                // then
+                assertThat(results.getTotalElements()).isEqualTo(0);
+            }
+        }
     }
 
-    @Test
-    @DisplayName("제목 검색 - 공백으로 검색 시 실패")
-    public void failToSearchQuestionByTitleUsingSpace() {
-        // given
-        String title = "     ";
-        int page = 0;
+    @Nested
+    @DisplayName("면접 질문 단건 조회")
+    public class QuestionSingleQuery {
 
-        // when
-        Page<QuestionDetailDto> results = questionService.searchQuestionsByTitle(title, page);
+        User user;
+        Question question;
 
-        // then
-        assertThat(results.getTotalElements()).isEqualTo(0);
-    }
+        @BeforeEach
+        public void beforeEach() {
+            user = userAccountRepository.save(User.builder()
+                    .loginId("test")
+                    .password("1234")
+                    .nickname("test_user")
+                    .email("test@gmail.com")
+                    .createdAt(LocalDateTime.now())
+                    .build());
+            question = questionRepository.save(Question.builder()
+                    .title("제목123")
+                    .questionText("내용123")
+                    .category(Category.builder().id(1L).build())
+                    .level(Level.builder().id(2L).build())
+                    .createdAt(LocalDateTime.now())
+                    .build());
+        }
 
-    @Test
-    @DisplayName("제목 검색 - 검색어 길이가 2보다 작을 시 실패")
-    public void failToSearchQuestionByTitleUsingShortTitle() {
-        // given
-        String title = "1";
-        int page = 0;
+        @Nested
+        @DisplayName("성공 케이스")
+        public class SuccessCases {
 
-        // when
-        Page<QuestionDetailDto> results = questionService.searchQuestionsByTitle(title, page);
+            @Test
+            @DisplayName("로그인하지 않은 경우")
+            public void successFindQuestionById() {
+                // given
+                long userId = 0L;
 
-        // then
-        assertThat(results.getTotalElements()).isEqualTo(0);
-    }
+                // when
+                QuestionDetailDto result = questionService.getQuestion(userId, question.getId());
 
-    @Transactional
-    @Test
-    @DisplayName("면접 질문 조회 - 성공")
-    public void successFindQuestionById() {
-        // given
-        Long questionId = 1L;
+                // then
+                assertThat(result).isNotNull();
+                assertThat(result.getId()).isEqualTo(question.getId());
+                assertThat(result.getTitle()).isEqualTo(question.getTitle());
+                assertThat(result.getQuestionText()).isEqualTo(question.getQuestionText());
+                assertThat(result.getCategory()).isEqualTo(question.getCategory().getCategory());
+                assertThat(result.getLevel()).isEqualTo(question.getLevel().getLevel());
+                assertThat(result.isBookmarked()).isFalse();
+                assertThat(result.getCreatedAt()).isEqualTo(question.getCreatedAt());
+                assertThat(result.getModifiedAt()).isNull();
+            }
 
-        // when
-        QuestionDetailDto result = questionService.getQuestion(questionId);
+            @Test
+            @DisplayName("로그인한 사용자, 북마크 등록되지 않은 면접 질문인 경우")
+            public void shouldReturnQuestionDetailDto_whenUserIsSignIn() {
+                // given
 
-        // then
-        assertThat(result.getId()).isEqualTo(questionId);
-    }
+                // when
+                QuestionDetailDto result = questionService.getQuestion(user.getId(), question.getId());
 
-    @Test
-    @DisplayName("면접 질문 조회 실패 - 유효하지 않은 ID로 조회하는 경우(EntityNotFoundException 반환)")
-    public void failToGetQuestion_whenUsingInvalidId() {
-        // given
-        Long questionId = 0L;
-        String errorMessage = "면접 질문을 찾을 수 없습니다.";
+                // then
+                assertThat(result).isNotNull();
+                assertThat(result.getId()).isEqualTo(question.getId());
+                assertThat(result.getTitle()).isEqualTo(question.getTitle());
+                assertThat(result.getQuestionText()).isEqualTo(question.getQuestionText());
+                assertThat(result.getCategory()).isEqualTo(question.getCategory().getCategory());
+                assertThat(result.getLevel()).isEqualTo(question.getLevel().getLevel());
+                assertThat(result.isBookmarked()).isFalse();
+                assertThat(result.getCreatedAt()).isEqualTo(question.getCreatedAt());
+                assertThat(result.getModifiedAt()).isNull();
+            }
 
-        // when & then
-        EntityNotFoundException exception = assertThrows(
-                EntityNotFoundException.class,
-                () -> questionService.getQuestion(questionId)
-        );
+            @Test
+            @DisplayName("로그인한 사용자, 북마크 등록된 면접 질문인 경우")
+            public void shouldReturnQuestionDetailDto_whenUserIsSignInAndBookmarkIsRegistered() {
+                // given
+                bookmarkRepository.save(Bookmark.builder()
+                        .id(new BookmarkId(user.getId(), question.getId()))
+                        .user(user)
+                        .question(question)
+                        .createdAt(LocalDateTime.now())
+                        .build());
 
-        assertThat(exception.getMessage()).isEqualTo(errorMessage);
+                // when
+                QuestionDetailDto result = questionService.getQuestion(user.getId(), question.getId());
+
+                // then
+                assertThat(result).isNotNull();
+                assertThat(result.getId()).isEqualTo(question.getId());
+                assertThat(result.getTitle()).isEqualTo(question.getTitle());
+                assertThat(result.getQuestionText()).isEqualTo(question.getQuestionText());
+                assertThat(result.getCategory()).isEqualTo(question.getCategory().getCategory());
+                assertThat(result.getLevel()).isEqualTo(question.getLevel().getLevel());
+                assertThat(result.isBookmarked()).isTrue();
+                assertThat(result.getCreatedAt()).isEqualTo(question.getCreatedAt());
+                assertThat(result.getModifiedAt()).isNull();
+            }
+        }
+
+        @Nested
+        @DisplayName("실패 케이스")
+        public class FailureCases {
+
+            @Test
+            @DisplayName("로그인하지 않은 사용자, 유효하지 않은 ID로 조회하는 경우 - EntityNotFoundException 반환")
+            public void shouldThrowEntityNotFoundException_whenUserIsNotSignInAndQuestionIdIsUnavailable() {
+                // given
+                long userId = 0L;
+                long questionId = 0L;
+
+                // when & then
+                EntityNotFoundException exception = assertThrows(
+                        EntityNotFoundException.class,
+                        () -> questionService.getQuestion(userId, questionId)
+                );
+
+                assertThat(exception.getMessage()).isEqualTo("면접 질문을 찾을 수 없습니다.");
+            }
+
+            @Test
+            @DisplayName("로그인한 사용자, 유효하지 않은 ID로 조회하는 경우 - EntityNotFoundException 반환")
+            public void failToGetQuestion_whenUsingInvalidId() {
+                // given
+                long userId = user.getId();
+                long questionId = 0L;
+
+                // when & then
+                EntityNotFoundException exception = assertThrows(
+                        EntityNotFoundException.class,
+                        () -> questionService.getQuestion(userId, questionId)
+                );
+
+                assertThat(exception.getMessage()).isEqualTo("면접 질문을 찾을 수 없습니다.");
+            }
+        }
     }
 }

--- a/src/test/java/com/upstage/devup/user/answer/service/UserAnswerSaveServiceTest.java
+++ b/src/test/java/com/upstage/devup/user/answer/service/UserAnswerSaveServiceTest.java
@@ -43,7 +43,7 @@ class UserAnswerSaveServiceTest {
         UserAnswerDetailDto result = userAnswerSaveService.saveUserAnswer(userId, request);
 
         // then
-        QuestionDetailDto questionDetailDto = questionService.getQuestion(questionId);
+        QuestionDetailDto questionDetailDto = questionService.getQuestion(userId, questionId);
 
         assertThat(result.getUserId()).isEqualTo(userId);
         assertThat(result.getQuestionId()).isEqualTo(questionId);


### PR DESCRIPTION
## 작업 내용

### 북마크 기능 추가
- 북마크 등록, 삭제, 목록으로 조회 기능 구현
- 컨트롤러, 서비스 테스트 코드 작성 및 통과 확인

### 화면 구현
- `문제 상세 페이지`에 `[북마크 추가]`, `[북마크 삭제]` 버튼 추가
- `마이페이지`에 `북마크 탭`을 추가해 북마크한 문제를 목록으로 보여줌

### `bookmarks` 테이블 및 ERD 수정
- 기존 기본키(`id`) 제거
- `user_id`, `question_id`를 기본키로 설정
- 북마크 등록일을 나타내는 `created_at` 속성 추가
- ERD(v1.0.3) 수정

## 북마크 관련 API
- 북마크 API는 항상 로그인 여부를 확인함

|기능|API|
|---|---|
|북마크 등록|`/api/bookmarks/{questionId}`|
|북마크 삭제|`/api/bookmarks/{questionId}`|
|북마크 목록 조회|`/api/bookmarks?pageNumber=`|