### PR TITLE
feat: 사용자 권한 추가

### DIFF
--- a/docs/erd/v1.0.4.erd
+++ b/docs/erd/v1.0.4.erd
@@ -1,0 +1,2292 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dineug/erd-editor/main/json-schema/schema.json",
+  "version": "3.0.0",
+  "settings": {
+    "width": 2500,
+    "height": 2500,
+    "scrollTop": 0,
+    "scrollLeft": 0,
+    "zoomLevel": 1,
+    "show": 511,
+    "database": 1,
+    "databaseName": "db_devup",
+    "canvasType": "@dineug/erd-editor/builtin-schema-sql",
+    "language": 1,
+    "tableNameCase": 4,
+    "columnNameCase": 2,
+    "bracketType": 1,
+    "relationshipDataTypeSync": true,
+    "relationshipOptimization": false,
+    "columnOrder": [
+      1,
+      2,
+      4,
+      8,
+      16,
+      32,
+      64
+    ],
+    "maxWidthComment": -1,
+    "ignoreSaveSettings": 3
+  },
+  "doc": {
+    "tableIds": [
+      "8aFrB5iymo97MeKM6QOXI",
+      "4t9_a2SYDDVe_lAz7fSqk",
+      "SbQWaRbeDbws5OYAat2iF",
+      "_CIKzC1_ech2NHfwtp4ZP",
+      "PoVTyDcupvCwdz-QrJw7w",
+      "LjZoHLvA6UqrBIsKzV7kT",
+      "7C0PRYdyvSrdq4I1cBFTL",
+      "QRtSx4RMjyg8xmvY7GPrI",
+      "TT8mGx9q7qEMOLs-p6KkS",
+      "aQ-DiY_134I285CtsweJ4",
+      "kMQzI88SfqJm3iYqRT182"
+    ],
+    "relationshipIds": [
+      "4EYlb6_xLtzqrHQIspM67",
+      "h_ZvyjoEt3T_6gYI1eCE_",
+      "CWCO8DL1lezTXlkDq3gZb",
+      "FJ4uWPOikKX9qZ7CLmTB8",
+      "rnhw3RJ5ONfpMD6O3Y93T",
+      "YynzCf6FhZdh0LInvD3cg",
+      "x6Efy3vQ-8CpwLvovCHrV",
+      "DqN3E3l5xsfe3Sa1XZ4Dn",
+      "6-Qey6CFqsAcyC7k2hZ3n",
+      "K9O1srgAORx6fZAajCiFB",
+      "hFZ9sFkiYbsCBR-qxEQb0",
+      "wpQoDXEiy2ArrkoCqJ2Fx",
+      "fjx5IkTcM3xKoEc7JNXD9"
+    ],
+    "indexIds": [],
+    "memoIds": []
+  },
+  "collections": {
+    "tableEntities": {
+      "8aFrB5iymo97MeKM6QOXI": {
+        "id": "8aFrB5iymo97MeKM6QOXI",
+        "name": "users",
+        "comment": "사용자",
+        "columnIds": [
+          "aZV1EX4pI-WE6FSIeloqW",
+          "YFkO2aFJNflrJjch2ibcC",
+          "rFuK4POI0HqmEBuWNYhqn",
+          "RMRXCxwA-f__F7UIAucE5",
+          "KC2LG2pIYz-isDobOn1R_",
+          "VdVG-GxuRGvG6_zfqTjXu",
+          "SO42rWN8-3tfCzsRImDTU",
+          "tVUTKcs-XoIH5n8MxRRXX"
+        ],
+        "seqColumnIds": [
+          "aZV1EX4pI-WE6FSIeloqW",
+          "YFkO2aFJNflrJjch2ibcC",
+          "rFuK4POI0HqmEBuWNYhqn",
+          "RMRXCxwA-f__F7UIAucE5",
+          "KC2LG2pIYz-isDobOn1R_",
+          "CNX12raDftYUgrP6baZjA",
+          "7987_F4x-uuSEoRAd0pgp",
+          "VdVG-GxuRGvG6_zfqTjXu",
+          "SO42rWN8-3tfCzsRImDTU",
+          "fPU5XqpnbKTZILAmTlFGo",
+          "9bDdtunMGmGy1kUfrfc4d",
+          "tVUTKcs-XoIH5n8MxRRXX"
+        ],
+        "ui": {
+          "x": 30.2187,
+          "y": 289.1023,
+          "zIndex": 2,
+          "widthName": 60,
+          "widthComment": 60,
+          "color": ""
+        },
+        "meta": {
+          "updateAt": 1749270153180,
+          "createAt": 1745495057235
+        }
+      },
+      "4t9_a2SYDDVe_lAz7fSqk": {
+        "id": "4t9_a2SYDDVe_lAz7fSqk",
+        "name": "questions",
+        "comment": "기술 면접 질문",
+        "columnIds": [
+          "y7mIA2j_HBZKM9Fe9yR2v",
+          "q9VC6MuGlAt2_fpvaU6YA",
+          "5KP0ckgTfofol7kffxTVM",
+          "jxmmoPgOw5fyFw6AqcBCS",
+          "7hHdemvf8tf1gBG5k8EXx",
+          "8tz3LfjKIvoR181yNvIz4",
+          "9thSvk11o4L2mrhR5RjNm"
+        ],
+        "seqColumnIds": [
+          "y7mIA2j_HBZKM9Fe9yR2v",
+          "q9VC6MuGlAt2_fpvaU6YA",
+          "5KP0ckgTfofol7kffxTVM",
+          "GrSkMikwA3JQjbUJ-dQEL",
+          "n7z_XQfXY1finPSoUd9EW",
+          "jxmmoPgOw5fyFw6AqcBCS",
+          "7hHdemvf8tf1gBG5k8EXx",
+          "MtBl8Va1Lk-mtDw2Duni6",
+          "8tz3LfjKIvoR181yNvIz4",
+          "9thSvk11o4L2mrhR5RjNm"
+        ],
+        "ui": {
+          "x": 1289.3499,
+          "y": 363.4294,
+          "zIndex": 57,
+          "widthName": 60,
+          "widthComment": 71,
+          "color": ""
+        },
+        "meta": {
+          "updateAt": 1749270038616,
+          "createAt": 1745497332800
+        }
+      },
+      "SbQWaRbeDbws5OYAat2iF": {
+        "id": "SbQWaRbeDbws5OYAat2iF",
+        "name": "categories",
+        "comment": "기술 면접 주제",
+        "columnIds": [
+          "bYBD1G5Rtzfd5bmHp1PSN",
+          "OwoHz7vQm9Tnz7aJJdNd-",
+          "eQVTYYo6DkFvrgl8uc08f"
+        ],
+        "seqColumnIds": [
+          "bYBD1G5Rtzfd5bmHp1PSN",
+          "OwoHz7vQm9Tnz7aJJdNd-",
+          "fHVQEcbx_VoYFmXnNu260",
+          "eQVTYYo6DkFvrgl8uc08f"
+        ],
+        "ui": {
+          "x": 1112.896,
+          "y": 1091.7079,
+          "zIndex": 67,
+          "widthName": 62,
+          "widthComment": 71,
+          "color": ""
+        },
+        "meta": {
+          "updateAt": 1749270063444,
+          "createAt": 1745497478333
+        }
+      },
+      "_CIKzC1_ech2NHfwtp4ZP": {
+        "id": "_CIKzC1_ech2NHfwtp4ZP",
+        "name": "levels",
+        "comment": "난이도",
+        "columnIds": [
+          "7-m0nv5D2FbXOnd4f4Bgm",
+          "PZNJcHrv12XoDKy1E94EA"
+        ],
+        "seqColumnIds": [
+          "7-m0nv5D2FbXOnd4f4Bgm",
+          "PZNJcHrv12XoDKy1E94EA"
+        ],
+        "ui": {
+          "x": 1446.3098,
+          "y": 943.1503,
+          "zIndex": 102,
+          "widthName": 60,
+          "widthComment": 60,
+          "color": ""
+        },
+        "meta": {
+          "updateAt": 1749270066226,
+          "createAt": 1745497833117
+        }
+      },
+      "PoVTyDcupvCwdz-QrJw7w": {
+        "id": "PoVTyDcupvCwdz-QrJw7w",
+        "name": "answers",
+        "comment": "정답",
+        "columnIds": [
+          "6MmB2EYoI2cu4yi23bMvK",
+          "LZTT3T0iLrGsGDiWojy6n",
+          "Y8byxGDS3por4Rl1B6n-g",
+          "PQR5v7z-Zw8WnzncBwO0d",
+          "zDUaZts6zMEyhxenWUtPu"
+        ],
+        "seqColumnIds": [
+          "mqVnVLgS3FSA4zpKu285m",
+          "6MmB2EYoI2cu4yi23bMvK",
+          "LZTT3T0iLrGsGDiWojy6n",
+          "Y8byxGDS3por4Rl1B6n-g",
+          "PQR5v7z-Zw8WnzncBwO0d",
+          "zDUaZts6zMEyhxenWUtPu"
+        ],
+        "ui": {
+          "x": 1360.1923,
+          "y": 37.3357,
+          "zIndex": 110,
+          "widthName": 60,
+          "widthComment": 60,
+          "color": ""
+        },
+        "meta": {
+          "updateAt": 1749269951726,
+          "createAt": 1745497874393
+        }
+      },
+      "LjZoHLvA6UqrBIsKzV7kT": {
+        "id": "LjZoHLvA6UqrBIsKzV7kT",
+        "name": "user_answers",
+        "comment": "유저가 작성한 정답",
+        "columnIds": [
+          "ZP3qUs4cZ1uQx7IswO1Fi",
+          "_gwHoDh2lO7fUm8OfzcUV",
+          "IrobFUndU4WWxGROXjnhj",
+          "2CuhpG8itwxd_cODm36Ap",
+          "33K9rBXrTQkvyxtO1pA_t",
+          "SpystaxktjoZuDCNluhs2"
+        ],
+        "seqColumnIds": [
+          "ZP3qUs4cZ1uQx7IswO1Fi",
+          "_gwHoDh2lO7fUm8OfzcUV",
+          "IrobFUndU4WWxGROXjnhj",
+          "2CuhpG8itwxd_cODm36Ap",
+          "33K9rBXrTQkvyxtO1pA_t",
+          "SpystaxktjoZuDCNluhs2",
+          "W9JLIXKYfvwzM7nbcUymM"
+        ],
+        "ui": {
+          "x": 636.888,
+          "y": 31.4471,
+          "zIndex": 131,
+          "widthName": 80,
+          "widthComment": 92,
+          "color": ""
+        },
+        "meta": {
+          "updateAt": 1749269992460,
+          "createAt": 1745498004462
+        }
+      },
+      "7C0PRYdyvSrdq4I1cBFTL": {
+        "id": "7C0PRYdyvSrdq4I1cBFTL",
+        "name": "wrong_answers",
+        "comment": "유저가 틀린 문제",
+        "columnIds": [
+          "-PXNhiZzRvwfVEOsVnoNK",
+          "kwiSsLPW9j-cKxdERkjtP",
+          "qYPjNCSt7PHgpL65cX_Dl",
+          "E8ARIRcuO3CQ6XjAGb9bi"
+        ],
+        "seqColumnIds": [
+          "HlcQFfMEtyLNioD7eK8Ll",
+          "-PXNhiZzRvwfVEOsVnoNK",
+          "kwiSsLPW9j-cKxdERkjtP",
+          "3y7H9HgdCD7DZHDRfcsbd",
+          "qYPjNCSt7PHgpL65cX_Dl",
+          "E8ARIRcuO3CQ6XjAGb9bi",
+          "skm1SlUBPVALol5gUJUeT"
+        ],
+        "ui": {
+          "x": 639.2126,
+          "y": 296.4071,
+          "zIndex": 147,
+          "widthName": 91,
+          "widthComment": 81,
+          "color": ""
+        },
+        "meta": {
+          "updateAt": 1749269988580,
+          "createAt": 1745498264054
+        }
+      },
+      "QRtSx4RMjyg8xmvY7GPrI": {
+        "id": "QRtSx4RMjyg8xmvY7GPrI",
+        "name": "bookmarks",
+        "comment": "북마크",
+        "columnIds": [
+          "H9QsMBnhPHJx0fL86Anxg",
+          "cyB0VtfkXoegatCzQQIfM",
+          "7bF4olHjFiJSnTgoz1OXG"
+        ],
+        "seqColumnIds": [
+          "VObppcT66U8dAJwRHZdKq",
+          "GgW95yo8hI83OdCmTVU61",
+          "H9QsMBnhPHJx0fL86Anxg",
+          "cyB0VtfkXoegatCzQQIfM",
+          "7bF4olHjFiJSnTgoz1OXG"
+        ],
+        "ui": {
+          "x": 589.5602,
+          "y": 781.1082,
+          "zIndex": 183,
+          "widthName": 64,
+          "widthComment": 60,
+          "color": ""
+        },
+        "meta": {
+          "updateAt": 1749270028593,
+          "createAt": 1745498474160
+        }
+      },
+      "TT8mGx9q7qEMOLs-p6KkS": {
+        "id": "TT8mGx9q7qEMOLs-p6KkS",
+        "name": "question_stats",
+        "comment": "문제 풀이 현황",
+        "columnIds": [
+          "AxmxKSsILSP0gONgkJopv",
+          "mABxR9m0G66KTu3BI1ZAU",
+          "h98uEhJOeet6KzjfOlBth",
+          "FJv128iZQYa6bUl9XgjCt"
+        ],
+        "seqColumnIds": [
+          "AxmxKSsILSP0gONgkJopv",
+          "mABxR9m0G66KTu3BI1ZAU",
+          "h98uEhJOeet6KzjfOlBth",
+          "FJv128iZQYa6bUl9XgjCt"
+        ],
+        "ui": {
+          "x": 783.8909,
+          "y": 930.1892,
+          "zIndex": 206,
+          "widthName": 85,
+          "widthComment": 71,
+          "color": ""
+        },
+        "meta": {
+          "updateAt": 1749270063444,
+          "createAt": 1745498558417
+        }
+      },
+      "aQ-DiY_134I285CtsweJ4": {
+        "id": "aQ-DiY_134I285CtsweJ4",
+        "name": "user_answer_stats",
+        "comment": "유저가 푼 문제 이력",
+        "columnIds": [
+          "aS7iktFYO7QmQnpU_jgmw",
+          "YN6wc1DOBjbxfESZ_gwha",
+          "r_rSI5a7OIWb5PA2M2Tm6",
+          "47uNiw3n7D7jKwSXEZgyr",
+          "4cei7VYy6xfmBuv8La_HL",
+          "TS3M0ZXZYWC-02VuuHhGJ",
+          "c8Bkdi6BJ_wN4BCR-3eif"
+        ],
+        "seqColumnIds": [
+          "aS7iktFYO7QmQnpU_jgmw",
+          "YN6wc1DOBjbxfESZ_gwha",
+          "nlGqItKDmvYXhsTBFwqx5",
+          "AM58umJfwjf2R609bUFA5",
+          "r_rSI5a7OIWb5PA2M2Tm6",
+          "47uNiw3n7D7jKwSXEZgyr",
+          "4cei7VYy6xfmBuv8La_HL",
+          "TS3M0ZXZYWC-02VuuHhGJ",
+          "c8Bkdi6BJ_wN4BCR-3eif"
+        ],
+        "ui": {
+          "x": 639.1924,
+          "y": 507.5341,
+          "zIndex": 335,
+          "widthName": 108,
+          "widthComment": 95,
+          "color": ""
+        },
+        "meta": {
+          "updateAt": 1749269982756,
+          "createAt": 1745507027071
+        }
+      },
+      "kMQzI88SfqJm3iYqRT182": {
+        "id": "kMQzI88SfqJm3iYqRT182",
+        "name": "roles",
+        "comment": "사용자 권한",
+        "columnIds": [
+          "eZDrxfmiydefjEPOy9HI2",
+          "Lj0APha3SuzsaK0zKK_xC",
+          "1i3v0z-O6GC1FWgpHurCV",
+          "QaFkR_XugL2Wr4pNZv19E",
+          "-kTtV53QbYVdXdVWjT7FP"
+        ],
+        "seqColumnIds": [
+          "eZDrxfmiydefjEPOy9HI2",
+          "Lj0APha3SuzsaK0zKK_xC",
+          "1i3v0z-O6GC1FWgpHurCV",
+          "QaFkR_XugL2Wr4pNZv19E",
+          "-kTtV53QbYVdXdVWjT7FP",
+          "QDH-DmYfykY2LWbQi5HNu"
+        ],
+        "ui": {
+          "x": 29,
+          "y": 30,
+          "zIndex": 336,
+          "widthName": 60,
+          "widthComment": 60,
+          "color": ""
+        },
+        "meta": {
+          "updateAt": 1749269830848,
+          "createAt": 1749268824533
+        }
+      }
+    },
+    "tableColumnEntities": {
+      "aZV1EX4pI-WE6FSIeloqW": {
+        "id": "aZV1EX4pI-WE6FSIeloqW",
+        "tableId": "8aFrB5iymo97MeKM6QOXI",
+        "name": "id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 11,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1746099323175,
+          "createAt": 1745495070543
+        }
+      },
+      "YFkO2aFJNflrJjch2ibcC": {
+        "id": "YFkO2aFJNflrJjch2ibcC",
+        "tableId": "8aFrB5iymo97MeKM6QOXI",
+        "name": "login_id",
+        "comment": "",
+        "dataType": "VARCHAR(100)",
+        "default": "",
+        "options": 12,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 89,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1745508937320,
+          "createAt": 1745495095017
+        }
+      },
+      "rFuK4POI0HqmEBuWNYhqn": {
+        "id": "rFuK4POI0HqmEBuWNYhqn",
+        "tableId": "8aFrB5iymo97MeKM6QOXI",
+        "name": "password",
+        "comment": "",
+        "dataType": "VARCHAR(255)",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 90,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1745507969736,
+          "createAt": 1745495194244
+        }
+      },
+      "RMRXCxwA-f__F7UIAucE5": {
+        "id": "RMRXCxwA-f__F7UIAucE5",
+        "tableId": "8aFrB5iymo97MeKM6QOXI",
+        "name": "nickname",
+        "comment": "",
+        "dataType": "VARCHAR(100)",
+        "default": "",
+        "options": 12,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 89,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1745507973170,
+          "createAt": 1745495194694
+        }
+      },
+      "KC2LG2pIYz-isDobOn1R_": {
+        "id": "KC2LG2pIYz-isDobOn1R_",
+        "tableId": "8aFrB5iymo97MeKM6QOXI",
+        "name": "email",
+        "comment": "이메일 인증 필요",
+        "dataType": "VARCHAR(200)",
+        "default": "",
+        "options": 12,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 81,
+          "widthDataType": 90,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1745508757860,
+          "createAt": 1745495195173
+        }
+      },
+      "y7mIA2j_HBZKM9Fe9yR2v": {
+        "id": "y7mIA2j_HBZKM9Fe9yR2v",
+        "tableId": "4t9_a2SYDDVe_lAz7fSqk",
+        "name": "id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 11,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1746099335324,
+          "createAt": 1745497380249
+        }
+      },
+      "q9VC6MuGlAt2_fpvaU6YA": {
+        "id": "q9VC6MuGlAt2_fpvaU6YA",
+        "tableId": "4t9_a2SYDDVe_lAz7fSqk",
+        "name": "title",
+        "comment": "",
+        "dataType": "VARCHAR(200)",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 90,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1745507919978,
+          "createAt": 1745497400900
+        }
+      },
+      "5KP0ckgTfofol7kffxTVM": {
+        "id": "5KP0ckgTfofol7kffxTVM",
+        "tableId": "4t9_a2SYDDVe_lAz7fSqk",
+        "name": "question_text",
+        "comment": "",
+        "dataType": "VARCHAR(2000)",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 79,
+          "widthComment": 60,
+          "widthDataType": 98,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1745508135111,
+          "createAt": 1745497428904
+        }
+      },
+      "GrSkMikwA3JQjbUJ-dQEL": {
+        "id": "GrSkMikwA3JQjbUJ-dQEL",
+        "tableId": "4t9_a2SYDDVe_lAz7fSqk",
+        "name": "",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1745497448255,
+          "createAt": 1745497438325
+        }
+      },
+      "bYBD1G5Rtzfd5bmHp1PSN": {
+        "id": "bYBD1G5Rtzfd5bmHp1PSN",
+        "tableId": "SbQWaRbeDbws5OYAat2iF",
+        "name": "id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 11,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1746099341191,
+          "createAt": 1745497493721
+        }
+      },
+      "OwoHz7vQm9Tnz7aJJdNd-": {
+        "id": "OwoHz7vQm9Tnz7aJJdNd-",
+        "tableId": "SbQWaRbeDbws5OYAat2iF",
+        "name": "category",
+        "comment": "",
+        "dataType": "VARCHAR(100)",
+        "default": "",
+        "options": 12,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 89,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1745508109610,
+          "createAt": 1745497505916
+        }
+      },
+      "fHVQEcbx_VoYFmXnNu260": {
+        "id": "fHVQEcbx_VoYFmXnNu260",
+        "tableId": "SbQWaRbeDbws5OYAat2iF",
+        "name": "questioid",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1745497735792,
+          "createAt": 1745497711277
+        }
+      },
+      "n7z_XQfXY1finPSoUd9EW": {
+        "id": "n7z_XQfXY1finPSoUd9EW",
+        "tableId": "4t9_a2SYDDVe_lAz7fSqk",
+        "name": "id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1745497746766,
+          "createAt": 1745497746766
+        }
+      },
+      "jxmmoPgOw5fyFw6AqcBCS": {
+        "id": "jxmmoPgOw5fyFw6AqcBCS",
+        "tableId": "4t9_a2SYDDVe_lAz7fSqk",
+        "name": "category_id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 2,
+          "widthName": 68,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1745497799559,
+          "createAt": 1745497787834
+        }
+      },
+      "7-m0nv5D2FbXOnd4f4Bgm": {
+        "id": "7-m0nv5D2FbXOnd4f4Bgm",
+        "tableId": "_CIKzC1_ech2NHfwtp4ZP",
+        "name": "id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 11,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1746099342873,
+          "createAt": 1745497844126
+        }
+      },
+      "PZNJcHrv12XoDKy1E94EA": {
+        "id": "PZNJcHrv12XoDKy1E94EA",
+        "tableId": "_CIKzC1_ech2NHfwtp4ZP",
+        "name": "level",
+        "comment": "",
+        "dataType": "VARCHAR(50)",
+        "default": "",
+        "options": 12,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 83,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1745508112116,
+          "createAt": 1745497853138
+        }
+      },
+      "7hHdemvf8tf1gBG5k8EXx": {
+        "id": "7hHdemvf8tf1gBG5k8EXx",
+        "tableId": "4t9_a2SYDDVe_lAz7fSqk",
+        "name": "level_id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 2,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1745497980460,
+          "createAt": 1745497867940
+        }
+      },
+      "mqVnVLgS3FSA4zpKu285m": {
+        "id": "mqVnVLgS3FSA4zpKu285m",
+        "tableId": "PoVTyDcupvCwdz-QrJw7w",
+        "name": "id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 13,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1745497897345,
+          "createAt": 1745497886829
+        }
+      },
+      "Y8byxGDS3por4Rl1B6n-g": {
+        "id": "Y8byxGDS3por4Rl1B6n-g",
+        "tableId": "PoVTyDcupvCwdz-QrJw7w",
+        "name": "answer_text",
+        "comment": "",
+        "dataType": "VARCHAR(1000)",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 70,
+          "widthComment": 60,
+          "widthDataType": 96,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1745508139865,
+          "createAt": 1745497901318
+        }
+      },
+      "LZTT3T0iLrGsGDiWojy6n": {
+        "id": "LZTT3T0iLrGsGDiWojy6n",
+        "tableId": "PoVTyDcupvCwdz-QrJw7w",
+        "name": "question_id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 2,
+          "widthName": 68,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1746098920727,
+          "createAt": 1745497930815
+        }
+      },
+      "2CuhpG8itwxd_cODm36Ap": {
+        "id": "2CuhpG8itwxd_cODm36Ap",
+        "tableId": "LjZoHLvA6UqrBIsKzV7kT",
+        "name": "answer_text",
+        "comment": "",
+        "dataType": "VARCHAR(2000)",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 70,
+          "widthComment": 60,
+          "widthDataType": 98,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1745508151790,
+          "createAt": 1745498012080
+        }
+      },
+      "33K9rBXrTQkvyxtO1pA_t": {
+        "id": "33K9rBXrTQkvyxtO1pA_t",
+        "tableId": "LjZoHLvA6UqrBIsKzV7kT",
+        "name": "is_correct",
+        "comment": "정답 여부(0: 오답, 1: 정답)",
+        "dataType": "BOOLEAN",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 132,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1745506990095,
+          "createAt": 1745498056361
+        }
+      },
+      "_gwHoDh2lO7fUm8OfzcUV": {
+        "id": "_gwHoDh2lO7fUm8OfzcUV",
+        "tableId": "LjZoHLvA6UqrBIsKzV7kT",
+        "name": "user_id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 2,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1745506972530,
+          "createAt": 1745498106079
+        }
+      },
+      "IrobFUndU4WWxGROXjnhj": {
+        "id": "IrobFUndU4WWxGROXjnhj",
+        "tableId": "LjZoHLvA6UqrBIsKzV7kT",
+        "name": "question_id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 2,
+          "widthName": 68,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1745506974014,
+          "createAt": 1745498120403
+        }
+      },
+      "HlcQFfMEtyLNioD7eK8Ll": {
+        "id": "HlcQFfMEtyLNioD7eK8Ll",
+        "tableId": "7C0PRYdyvSrdq4I1cBFTL",
+        "name": "",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1745498265328,
+          "createAt": 1745498265328
+        }
+      },
+      "kwiSsLPW9j-cKxdERkjtP": {
+        "id": "kwiSsLPW9j-cKxdERkjtP",
+        "tableId": "7C0PRYdyvSrdq4I1cBFTL",
+        "name": "user_id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 2,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1746098928207,
+          "createAt": 1745498297182
+        }
+      },
+      "3y7H9HgdCD7DZHDRfcsbd": {
+        "id": "3y7H9HgdCD7DZHDRfcsbd",
+        "tableId": "7C0PRYdyvSrdq4I1cBFTL",
+        "name": "",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1745498299505,
+          "createAt": 1745498299505
+        }
+      },
+      "qYPjNCSt7PHgpL65cX_Dl": {
+        "id": "qYPjNCSt7PHgpL65cX_Dl",
+        "tableId": "7C0PRYdyvSrdq4I1cBFTL",
+        "name": "question_id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 2,
+          "widthName": 68,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1746098928971,
+          "createAt": 1745498314781
+        }
+      },
+      "VObppcT66U8dAJwRHZdKq": {
+        "id": "VObppcT66U8dAJwRHZdKq",
+        "tableId": "QRtSx4RMjyg8xmvY7GPrI",
+        "name": "",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1745498481828,
+          "createAt": 1745498481828
+        }
+      },
+      "H9QsMBnhPHJx0fL86Anxg": {
+        "id": "H9QsMBnhPHJx0fL86Anxg",
+        "tableId": "QRtSx4RMjyg8xmvY7GPrI",
+        "name": "user_id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 3,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1749213220275,
+          "createAt": 1745498495079
+        }
+      },
+      "cyB0VtfkXoegatCzQQIfM": {
+        "id": "cyB0VtfkXoegatCzQQIfM",
+        "tableId": "QRtSx4RMjyg8xmvY7GPrI",
+        "name": "question_id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 3,
+          "widthName": 68,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1749213221774,
+          "createAt": 1745498508788
+        }
+      },
+      "h98uEhJOeet6KzjfOlBth": {
+        "id": "h98uEhJOeet6KzjfOlBth",
+        "tableId": "TT8mGx9q7qEMOLs-p6KkS",
+        "name": "total_attempts",
+        "comment": "전체 풀이 시도 횟수",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 85,
+          "widthComment": 95,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1745498629955,
+          "createAt": 1745498571588
+        }
+      },
+      "mABxR9m0G66KTu3BI1ZAU": {
+        "id": "mABxR9m0G66KTu3BI1ZAU",
+        "tableId": "TT8mGx9q7qEMOLs-p6KkS",
+        "name": "question_id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 2,
+          "widthName": 68,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1746098923108,
+          "createAt": 1745498578313
+        }
+      },
+      "FJv128iZQYa6bUl9XgjCt": {
+        "id": "FJv128iZQYa6bUl9XgjCt",
+        "tableId": "TT8mGx9q7qEMOLs-p6KkS",
+        "name": "correct_count",
+        "comment": "정답 횟수",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 82,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1745498641149,
+          "createAt": 1745498630483
+        }
+      },
+      "ZP3qUs4cZ1uQx7IswO1Fi": {
+        "id": "ZP3qUs4cZ1uQx7IswO1Fi",
+        "tableId": "LjZoHLvA6UqrBIsKzV7kT",
+        "name": "id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 11,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1746099338538,
+          "createAt": 1745506955990
+        }
+      },
+      "SpystaxktjoZuDCNluhs2": {
+        "id": "SpystaxktjoZuDCNluhs2",
+        "tableId": "LjZoHLvA6UqrBIsKzV7kT",
+        "name": "created_at",
+        "comment": "제출 시간",
+        "dataType": "TIMESTAMP",
+        "default": "CURRENT_TIMESTAMP",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 63,
+          "widthComment": 60,
+          "widthDataType": 71,
+          "widthDefault": 133
+        },
+        "meta": {
+          "updateAt": 1745508898740,
+          "createAt": 1745506994684
+        }
+      },
+      "c8Bkdi6BJ_wN4BCR-3eif": {
+        "id": "c8Bkdi6BJ_wN4BCR-3eif",
+        "tableId": "aQ-DiY_134I285CtsweJ4",
+        "name": "last_solved_at",
+        "comment": "",
+        "dataType": "TIMESTAMP",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 84,
+          "widthComment": 60,
+          "widthDataType": 71,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1746533458314,
+          "createAt": 1745507047082
+        }
+      },
+      "YN6wc1DOBjbxfESZ_gwha": {
+        "id": "YN6wc1DOBjbxfESZ_gwha",
+        "tableId": "aQ-DiY_134I285CtsweJ4",
+        "name": "user_id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 2,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1746098926361,
+          "createAt": 1745507072634
+        }
+      },
+      "nlGqItKDmvYXhsTBFwqx5": {
+        "id": "nlGqItKDmvYXhsTBFwqx5",
+        "tableId": "aQ-DiY_134I285CtsweJ4",
+        "name": "id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1745507078198,
+          "createAt": 1745507078198
+        }
+      },
+      "AM58umJfwjf2R609bUFA5": {
+        "id": "AM58umJfwjf2R609bUFA5",
+        "tableId": "aQ-DiY_134I285CtsweJ4",
+        "name": "id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1745507085653,
+          "createAt": 1745507085653
+        }
+      },
+      "r_rSI5a7OIWb5PA2M2Tm6": {
+        "id": "r_rSI5a7OIWb5PA2M2Tm6",
+        "tableId": "aQ-DiY_134I285CtsweJ4",
+        "name": "question_id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 2,
+          "widthName": 68,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1746098927051,
+          "createAt": 1745507097833
+        }
+      },
+      "E8ARIRcuO3CQ6XjAGb9bi": {
+        "id": "E8ARIRcuO3CQ6XjAGb9bi",
+        "tableId": "7C0PRYdyvSrdq4I1cBFTL",
+        "name": "created_at",
+        "comment": "",
+        "dataType": "TIMESTAMP",
+        "default": "CURRENT_TIMESTAMP",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 63,
+          "widthComment": 60,
+          "widthDataType": 71,
+          "widthDefault": 133
+        },
+        "meta": {
+          "updateAt": 1745508888133,
+          "createAt": 1745507160031
+        }
+      },
+      "8tz3LfjKIvoR181yNvIz4": {
+        "id": "8tz3LfjKIvoR181yNvIz4",
+        "tableId": "4t9_a2SYDDVe_lAz7fSqk",
+        "name": "created_at",
+        "comment": "",
+        "dataType": "TIMESTAMP",
+        "default": "CURRENT_TIMESTAMP",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 63,
+          "widthComment": 60,
+          "widthDataType": 71,
+          "widthDefault": 133
+        },
+        "meta": {
+          "updateAt": 1745508896011,
+          "createAt": 1745508166114
+        }
+      },
+      "9thSvk11o4L2mrhR5RjNm": {
+        "id": "9thSvk11o4L2mrhR5RjNm",
+        "tableId": "4t9_a2SYDDVe_lAz7fSqk",
+        "name": "modified_at",
+        "comment": "",
+        "dataType": "TIMESTAMP",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 69,
+          "widthComment": 60,
+          "widthDataType": 71,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1745508192935,
+          "createAt": 1745508174710
+        }
+      },
+      "PQR5v7z-Zw8WnzncBwO0d": {
+        "id": "PQR5v7z-Zw8WnzncBwO0d",
+        "tableId": "PoVTyDcupvCwdz-QrJw7w",
+        "name": "created_at",
+        "comment": "",
+        "dataType": "TIMESTAMP",
+        "default": "CURRENT_TIMESTAMP",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 63,
+          "widthComment": 60,
+          "widthDataType": 71,
+          "widthDefault": 133
+        },
+        "meta": {
+          "updateAt": 1745508893054,
+          "createAt": 1745508205930
+        }
+      },
+      "zDUaZts6zMEyhxenWUtPu": {
+        "id": "zDUaZts6zMEyhxenWUtPu",
+        "tableId": "PoVTyDcupvCwdz-QrJw7w",
+        "name": "modified_at",
+        "comment": "",
+        "dataType": "TIMESTAMP",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 69,
+          "widthComment": 60,
+          "widthDataType": 71,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1745508218916,
+          "createAt": 1745508214175
+        }
+      },
+      "CNX12raDftYUgrP6baZjA": {
+        "id": "CNX12raDftYUgrP6baZjA",
+        "tableId": "8aFrB5iymo97MeKM6QOXI",
+        "name": "created_at",
+        "comment": "",
+        "dataType": "TIMESTAMP",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 63,
+          "widthComment": 60,
+          "widthDataType": 71,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1745508259040,
+          "createAt": 1745508253206
+        }
+      },
+      "7987_F4x-uuSEoRAd0pgp": {
+        "id": "7987_F4x-uuSEoRAd0pgp",
+        "tableId": "8aFrB5iymo97MeKM6QOXI",
+        "name": "modified_at",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 69,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1745508280805,
+          "createAt": 1745508261335
+        }
+      },
+      "W9JLIXKYfvwzM7nbcUymM": {
+        "id": "W9JLIXKYfvwzM7nbcUymM",
+        "tableId": "LjZoHLvA6UqrBIsKzV7kT",
+        "name": "modified_at",
+        "comment": "",
+        "dataType": "TIMESTAMP",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 69,
+          "widthComment": 60,
+          "widthDataType": 71,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1745508273492,
+          "createAt": 1745508273492
+        }
+      },
+      "VdVG-GxuRGvG6_zfqTjXu": {
+        "id": "VdVG-GxuRGvG6_zfqTjXu",
+        "tableId": "8aFrB5iymo97MeKM6QOXI",
+        "name": "created_at",
+        "comment": "",
+        "dataType": "TIMESTAMP",
+        "default": "CURRENT_TIMESTAMP",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 63,
+          "widthComment": 60,
+          "widthDataType": 71,
+          "widthDefault": 133
+        },
+        "meta": {
+          "updateAt": 1745508880278,
+          "createAt": 1745508284769
+        }
+      },
+      "SO42rWN8-3tfCzsRImDTU": {
+        "id": "SO42rWN8-3tfCzsRImDTU",
+        "tableId": "8aFrB5iymo97MeKM6QOXI",
+        "name": "modified_at",
+        "comment": "",
+        "dataType": "TIMESTAMP",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 69,
+          "widthComment": 60,
+          "widthDataType": 71,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1745508756600,
+          "createAt": 1745508284769
+        }
+      },
+      "6MmB2EYoI2cu4yi23bMvK": {
+        "id": "6MmB2EYoI2cu4yi23bMvK",
+        "tableId": "PoVTyDcupvCwdz-QrJw7w",
+        "name": "id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 11,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1746099336871,
+          "createAt": 1746098908674
+        }
+      },
+      "AxmxKSsILSP0gONgkJopv": {
+        "id": "AxmxKSsILSP0gONgkJopv",
+        "tableId": "TT8mGx9q7qEMOLs-p6KkS",
+        "name": "id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 11,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1746099327555,
+          "createAt": 1746098938351
+        }
+      },
+      "GgW95yo8hI83OdCmTVU61": {
+        "id": "GgW95yo8hI83OdCmTVU61",
+        "tableId": "QRtSx4RMjyg8xmvY7GPrI",
+        "name": "id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 11,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1746099325830,
+          "createAt": 1746098944369
+        }
+      },
+      "aS7iktFYO7QmQnpU_jgmw": {
+        "id": "aS7iktFYO7QmQnpU_jgmw",
+        "tableId": "aQ-DiY_134I285CtsweJ4",
+        "name": "id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 11,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1746099329235,
+          "createAt": 1746098954167
+        }
+      },
+      "-PXNhiZzRvwfVEOsVnoNK": {
+        "id": "-PXNhiZzRvwfVEOsVnoNK",
+        "tableId": "7C0PRYdyvSrdq4I1cBFTL",
+        "name": "id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 11,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1746099331189,
+          "createAt": 1746098960582
+        }
+      },
+      "skm1SlUBPVALol5gUJUeT": {
+        "id": "skm1SlUBPVALol5gUJUeT",
+        "tableId": "7C0PRYdyvSrdq4I1cBFTL",
+        "name": "",
+        "comment": "",
+        "dataType": "",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1746099068312,
+          "createAt": 1746099068312
+        }
+      },
+      "MtBl8Va1Lk-mtDw2Duni6": {
+        "id": "MtBl8Va1Lk-mtDw2Duni6",
+        "tableId": "4t9_a2SYDDVe_lAz7fSqk",
+        "name": "answer_id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1746099593457,
+          "createAt": 1746099572875
+        }
+      },
+      "47uNiw3n7D7jKwSXEZgyr": {
+        "id": "47uNiw3n7D7jKwSXEZgyr",
+        "tableId": "aQ-DiY_134I285CtsweJ4",
+        "name": "correct_count",
+        "comment": "맞춘 횟수",
+        "dataType": "INT",
+        "default": "0",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 82,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1746533469208,
+          "createAt": 1746533389976
+        }
+      },
+      "4cei7VYy6xfmBuv8La_HL": {
+        "id": "4cei7VYy6xfmBuv8La_HL",
+        "tableId": "aQ-DiY_134I285CtsweJ4",
+        "name": "wrong_count",
+        "comment": "틀릿 횟수",
+        "dataType": "INT",
+        "default": "0",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 76,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1746533422137,
+          "createAt": 1746533407746
+        }
+      },
+      "TS3M0ZXZYWC-02VuuHhGJ": {
+        "id": "TS3M0ZXZYWC-02VuuHhGJ",
+        "tableId": "aQ-DiY_134I285CtsweJ4",
+        "name": "first_solved_at",
+        "comment": "",
+        "dataType": "TIMESTAMP",
+        "default": "CURRENT_TIMESTAMP",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 86,
+          "widthComment": 60,
+          "widthDataType": 71,
+          "widthDefault": 133
+        },
+        "meta": {
+          "updateAt": 1746533479257,
+          "createAt": 1746533423139
+        }
+      },
+      "eQVTYYo6DkFvrgl8uc08f": {
+        "id": "eQVTYYo6DkFvrgl8uc08f",
+        "tableId": "SbQWaRbeDbws5OYAat2iF",
+        "name": "color",
+        "comment": "카테고리 바에 표시할 색상",
+        "dataType": "VARCHAR(10)",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 126,
+          "widthDataType": 81,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1747190833888,
+          "createAt": 1747190800779
+        }
+      },
+      "7bF4olHjFiJSnTgoz1OXG": {
+        "id": "7bF4olHjFiJSnTgoz1OXG",
+        "tableId": "QRtSx4RMjyg8xmvY7GPrI",
+        "name": "created_at",
+        "comment": "",
+        "dataType": "TIMESTAMP",
+        "default": "CURRENT_TIMESTAMP",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 63,
+          "widthComment": 60,
+          "widthDataType": 71,
+          "widthDefault": 133
+        },
+        "meta": {
+          "updateAt": 1749213244408,
+          "createAt": 1749213223434
+        }
+      },
+      "eZDrxfmiydefjEPOy9HI2": {
+        "id": "eZDrxfmiydefjEPOy9HI2",
+        "tableId": "kMQzI88SfqJm3iYqRT182",
+        "name": "id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 11,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1749269835959,
+          "createAt": 1749268837068
+        }
+      },
+      "Lj0APha3SuzsaK0zKK_xC": {
+        "id": "Lj0APha3SuzsaK0zKK_xC",
+        "tableId": "kMQzI88SfqJm3iYqRT182",
+        "name": "role_name",
+        "comment": "권한 이름",
+        "dataType": "VARCHAR(30)",
+        "default": "",
+        "options": 12,
+        "ui": {
+          "keys": 0,
+          "widthName": 61,
+          "widthComment": 60,
+          "widthDataType": 83,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1749268871477,
+          "createAt": 1749268848319
+        }
+      },
+      "1i3v0z-O6GC1FWgpHurCV": {
+        "id": "1i3v0z-O6GC1FWgpHurCV",
+        "tableId": "kMQzI88SfqJm3iYqRT182",
+        "name": "description",
+        "comment": "권한 설명",
+        "dataType": "VARCHAR(100)",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 65,
+          "widthComment": 60,
+          "widthDataType": 89,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1749268890814,
+          "createAt": 1749268872380
+        }
+      },
+      "QaFkR_XugL2Wr4pNZv19E": {
+        "id": "QaFkR_XugL2Wr4pNZv19E",
+        "tableId": "kMQzI88SfqJm3iYqRT182",
+        "name": "created_at",
+        "comment": "등록일",
+        "dataType": "TIMESTAMP",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 63,
+          "widthComment": 60,
+          "widthDataType": 71,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1749268906159,
+          "createAt": 1749268891476
+        }
+      },
+      "-kTtV53QbYVdXdVWjT7FP": {
+        "id": "-kTtV53QbYVdXdVWjT7FP",
+        "tableId": "kMQzI88SfqJm3iYqRT182",
+        "name": "modified_at",
+        "comment": "수정일",
+        "dataType": "TIMESTAMP",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 69,
+          "widthComment": 60,
+          "widthDataType": 71,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1749268916160,
+          "createAt": 1749268906686
+        }
+      },
+      "QDH-DmYfykY2LWbQi5HNu": {
+        "id": "QDH-DmYfykY2LWbQi5HNu",
+        "tableId": "kMQzI88SfqJm3iYqRT182",
+        "name": "",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1749268944812,
+          "createAt": 1749268934198
+        }
+      },
+      "fPU5XqpnbKTZILAmTlFGo": {
+        "id": "fPU5XqpnbKTZILAmTlFGo",
+        "tableId": "8aFrB5iymo97MeKM6QOXI",
+        "name": "role_id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1749268959067,
+          "createAt": 1749268936098
+        }
+      },
+      "9bDdtunMGmGy1kUfrfc4d": {
+        "id": "9bDdtunMGmGy1kUfrfc4d",
+        "tableId": "8aFrB5iymo97MeKM6QOXI",
+        "name": "role_id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1749269864921,
+          "createAt": 1749269859495
+        }
+      },
+      "tVUTKcs-XoIH5n8MxRRXX": {
+        "id": "tVUTKcs-XoIH5n8MxRRXX",
+        "tableId": "8aFrB5iymo97MeKM6QOXI",
+        "name": "role_id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 2,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1749270158889,
+          "createAt": 1749270153180
+        }
+      }
+    },
+    "relationshipEntities": {
+      "4EYlb6_xLtzqrHQIspM67": {
+        "id": "4EYlb6_xLtzqrHQIspM67",
+        "identification": false,
+        "relationshipType": 16,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "SbQWaRbeDbws5OYAat2iF",
+          "columnIds": [
+            "bYBD1G5Rtzfd5bmHp1PSN"
+          ],
+          "x": 1369.396,
+          "y": 1091.7079,
+          "direction": 4
+        },
+        "end": {
+          "tableId": "4t9_a2SYDDVe_lAz7fSqk",
+          "columnIds": [
+            "jxmmoPgOw5fyFw6AqcBCS"
+          ],
+          "x": 1563.3499000000002,
+          "y": 587.4294,
+          "direction": 8
+        },
+        "meta": {
+          "updateAt": 1745497787834,
+          "createAt": 1745497787834
+        }
+      },
+      "h_ZvyjoEt3T_6gYI1eCE_": {
+        "id": "h_ZvyjoEt3T_6gYI1eCE_",
+        "identification": false,
+        "relationshipType": 16,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "_CIKzC1_ech2NHfwtp4ZP",
+          "columnIds": [
+            "7-m0nv5D2FbXOnd4f4Bgm"
+          ],
+          "x": 1666.8098,
+          "y": 943.1503,
+          "direction": 4
+        },
+        "end": {
+          "tableId": "4t9_a2SYDDVe_lAz7fSqk",
+          "columnIds": [
+            "7hHdemvf8tf1gBG5k8EXx"
+          ],
+          "x": 1746.016566666667,
+          "y": 587.4294,
+          "direction": 8
+        },
+        "meta": {
+          "updateAt": 1745497867940,
+          "createAt": 1745497867940
+        }
+      },
+      "CWCO8DL1lezTXlkDq3gZb": {
+        "id": "CWCO8DL1lezTXlkDq3gZb",
+        "identification": false,
+        "relationshipType": 8,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "4t9_a2SYDDVe_lAz7fSqk",
+          "columnIds": [
+            "y7mIA2j_HBZKM9Fe9yR2v"
+          ],
+          "x": 1563.3499,
+          "y": 363.4294,
+          "direction": 4
+        },
+        "end": {
+          "tableId": "PoVTyDcupvCwdz-QrJw7w",
+          "columnIds": [
+            "LZTT3T0iLrGsGDiWojy6n"
+          ],
+          "x": 1628.6923,
+          "y": 213.3357,
+          "direction": 8
+        },
+        "meta": {
+          "updateAt": 1745497930816,
+          "createAt": 1745497930816
+        }
+      },
+      "FJ4uWPOikKX9qZ7CLmTB8": {
+        "id": "FJ4uWPOikKX9qZ7CLmTB8",
+        "identification": false,
+        "relationshipType": 16,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "8aFrB5iymo97MeKM6QOXI",
+          "columnIds": [
+            "aZV1EX4pI-WE6FSIeloqW"
+          ],
+          "x": 581.2187,
+          "y": 330.4356333333333,
+          "direction": 2
+        },
+        "end": {
+          "tableId": "LjZoHLvA6UqrBIsKzV7kT",
+          "columnIds": [
+            "_gwHoDh2lO7fUm8OfzcUV"
+          ],
+          "x": 636.888,
+          "y": 131.4471,
+          "direction": 1
+        },
+        "meta": {
+          "updateAt": 1745498106079,
+          "createAt": 1745498106079
+        }
+      },
+      "rnhw3RJ5ONfpMD6O3Y93T": {
+        "id": "rnhw3RJ5ONfpMD6O3Y93T",
+        "identification": false,
+        "relationshipType": 16,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "4t9_a2SYDDVe_lAz7fSqk",
+          "columnIds": [
+            "y7mIA2j_HBZKM9Fe9yR2v"
+          ],
+          "x": 1289.3499,
+          "y": 391.4294,
+          "direction": 1
+        },
+        "end": {
+          "tableId": "LjZoHLvA6UqrBIsKzV7kT",
+          "columnIds": [
+            "IrobFUndU4WWxGROXjnhj"
+          ],
+          "x": 1247.888,
+          "y": 131.4471,
+          "direction": 2
+        },
+        "meta": {
+          "updateAt": 1745498120403,
+          "createAt": 1745498120403
+        }
+      },
+      "YynzCf6FhZdh0LInvD3cg": {
+        "id": "YynzCf6FhZdh0LInvD3cg",
+        "identification": false,
+        "relationshipType": 16,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "8aFrB5iymo97MeKM6QOXI",
+          "columnIds": [
+            "aZV1EX4pI-WE6FSIeloqW"
+          ],
+          "x": 581.2187,
+          "y": 413.1023,
+          "direction": 2
+        },
+        "end": {
+          "tableId": "7C0PRYdyvSrdq4I1cBFTL",
+          "columnIds": [
+            "kwiSsLPW9j-cKxdERkjtP"
+          ],
+          "x": 639.2126,
+          "y": 372.4071,
+          "direction": 1
+        },
+        "meta": {
+          "updateAt": 1745498297183,
+          "createAt": 1745498297183
+        }
+      },
+      "x6Efy3vQ-8CpwLvovCHrV": {
+        "id": "x6Efy3vQ-8CpwLvovCHrV",
+        "identification": false,
+        "relationshipType": 16,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "4t9_a2SYDDVe_lAz7fSqk",
+          "columnIds": [
+            "y7mIA2j_HBZKM9Fe9yR2v"
+          ],
+          "x": 1289.3499,
+          "y": 447.4294,
+          "direction": 1
+        },
+        "end": {
+          "tableId": "7C0PRYdyvSrdq4I1cBFTL",
+          "columnIds": [
+            "qYPjNCSt7PHgpL65cX_Dl"
+          ],
+          "x": 1149.2125999999998,
+          "y": 372.4071,
+          "direction": 2
+        },
+        "meta": {
+          "updateAt": 1745498314781,
+          "createAt": 1745498314781
+        }
+      },
+      "DqN3E3l5xsfe3Sa1XZ4Dn": {
+        "id": "DqN3E3l5xsfe3Sa1XZ4Dn",
+        "identification": true,
+        "relationshipType": 16,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "8aFrB5iymo97MeKM6QOXI",
+          "columnIds": [
+            "aZV1EX4pI-WE6FSIeloqW"
+          ],
+          "x": 305.7187,
+          "y": 537.1023,
+          "direction": 8
+        },
+        "end": {
+          "tableId": "QRtSx4RMjyg8xmvY7GPrI",
+          "columnIds": [
+            "H9QsMBnhPHJx0fL86Anxg"
+          ],
+          "x": 589.5602,
+          "y": 845.1082,
+          "direction": 1
+        },
+        "meta": {
+          "updateAt": 1745498495080,
+          "createAt": 1745498495080
+        }
+      },
+      "6-Qey6CFqsAcyC7k2hZ3n": {
+        "id": "6-Qey6CFqsAcyC7k2hZ3n",
+        "identification": true,
+        "relationshipType": 16,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "4t9_a2SYDDVe_lAz7fSqk",
+          "columnIds": [
+            "y7mIA2j_HBZKM9Fe9yR2v"
+          ],
+          "x": 1289.3499,
+          "y": 559.4294,
+          "direction": 1
+        },
+        "end": {
+          "tableId": "QRtSx4RMjyg8xmvY7GPrI",
+          "columnIds": [
+            "cyB0VtfkXoegatCzQQIfM"
+          ],
+          "x": 1099.5602,
+          "y": 845.1082,
+          "direction": 2
+        },
+        "meta": {
+          "updateAt": 1745498508788,
+          "createAt": 1745498508788
+        }
+      },
+      "K9O1srgAORx6fZAajCiFB": {
+        "id": "K9O1srgAORx6fZAajCiFB",
+        "identification": false,
+        "relationshipType": 16,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "4t9_a2SYDDVe_lAz7fSqk",
+          "columnIds": [
+            "y7mIA2j_HBZKM9Fe9yR2v"
+          ],
+          "x": 1380.6832333333334,
+          "y": 587.4294,
+          "direction": 8
+        },
+        "end": {
+          "tableId": "TT8mGx9q7qEMOLs-p6KkS",
+          "columnIds": [
+            "mABxR9m0G66KTu3BI1ZAU"
+          ],
+          "x": 1261.8908999999999,
+          "y": 1006.1892,
+          "direction": 2
+        },
+        "meta": {
+          "updateAt": 1745498578313,
+          "createAt": 1745498578313
+        }
+      },
+      "hFZ9sFkiYbsCBR-qxEQb0": {
+        "id": "hFZ9sFkiYbsCBR-qxEQb0",
+        "identification": false,
+        "relationshipType": 16,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "8aFrB5iymo97MeKM6QOXI",
+          "columnIds": [
+            "aZV1EX4pI-WE6FSIeloqW"
+          ],
+          "x": 581.2187,
+          "y": 495.7689666666667,
+          "direction": 2
+        },
+        "end": {
+          "tableId": "aQ-DiY_134I285CtsweJ4",
+          "columnIds": [
+            "YN6wc1DOBjbxfESZ_gwha"
+          ],
+          "x": 639.1924,
+          "y": 619.5341000000001,
+          "direction": 1
+        },
+        "meta": {
+          "updateAt": 1745507072634,
+          "createAt": 1745507072634
+        }
+      },
+      "wpQoDXEiy2ArrkoCqJ2Fx": {
+        "id": "wpQoDXEiy2ArrkoCqJ2Fx",
+        "identification": false,
+        "relationshipType": 16,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "4t9_a2SYDDVe_lAz7fSqk",
+          "columnIds": [
+            "y7mIA2j_HBZKM9Fe9yR2v"
+          ],
+          "x": 1289.3499,
+          "y": 503.4294,
+          "direction": 1
+        },
+        "end": {
+          "tableId": "aQ-DiY_134I285CtsweJ4",
+          "columnIds": [
+            "r_rSI5a7OIWb5PA2M2Tm6"
+          ],
+          "x": 1167.1924,
+          "y": 619.5341000000001,
+          "direction": 2
+        },
+        "meta": {
+          "updateAt": 1745507097833,
+          "createAt": 1745507097833
+        }
+      },
+      "O_4aBpc0grzyFAGgJAWly": {
+        "id": "O_4aBpc0grzyFAGgJAWly",
+        "identification": false,
+        "relationshipType": 16,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "kMQzI88SfqJm3iYqRT182",
+          "columnIds": [
+            "QDH-DmYfykY2LWbQi5HNu"
+          ],
+          "x": 257,
+          "y": 230,
+          "direction": 8
+        },
+        "end": {
+          "tableId": "8aFrB5iymo97MeKM6QOXI",
+          "columnIds": [
+            "fPU5XqpnbKTZILAmTlFGo"
+          ],
+          "x": 305.7187,
+          "y": 352.1023,
+          "direction": 4
+        },
+        "meta": {
+          "updateAt": 1749268936098,
+          "createAt": 1749268936098
+        }
+      },
+      "RPUpuf7L23BB7TuHWWfL_": {
+        "id": "RPUpuf7L23BB7TuHWWfL_",
+        "identification": false,
+        "relationshipType": 16,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "kMQzI88SfqJm3iYqRT182",
+          "columnIds": [
+            "eZDrxfmiydefjEPOy9HI2"
+          ],
+          "x": 257,
+          "y": 206,
+          "direction": 8
+        },
+        "end": {
+          "tableId": "8aFrB5iymo97MeKM6QOXI",
+          "columnIds": [
+            "9bDdtunMGmGy1kUfrfc4d"
+          ],
+          "x": 305.7187,
+          "y": 289.1023,
+          "direction": 4
+        },
+        "meta": {
+          "updateAt": 1749269859495,
+          "createAt": 1749269859495
+        }
+      },
+      "fjx5IkTcM3xKoEc7JNXD9": {
+        "id": "fjx5IkTcM3xKoEc7JNXD9",
+        "identification": false,
+        "relationshipType": 16,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "kMQzI88SfqJm3iYqRT182",
+          "columnIds": [
+            "eZDrxfmiydefjEPOy9HI2"
+          ],
+          "x": 257,
+          "y": 206,
+          "direction": 8
+        },
+        "end": {
+          "tableId": "8aFrB5iymo97MeKM6QOXI",
+          "columnIds": [
+            "tVUTKcs-XoIH5n8MxRRXX"
+          ],
+          "x": 305.7187,
+          "y": 289.1023,
+          "direction": 4
+        },
+        "meta": {
+          "updateAt": 1749270153181,
+          "createAt": 1749270153181
+        }
+      }
+    },
+    "indexEntities": {},
+    "indexColumnEntities": {},
+    "memoEntities": {}
+  }
+}

--- a/src/main/java/com/upstage/devup/auth/config/AuthenticatedUser.java
+++ b/src/main/java/com/upstage/devup/auth/config/AuthenticatedUser.java
@@ -1,12 +1,7 @@
 package com.upstage.devup.auth.config;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
-@Getter
-@AllArgsConstructor
-public class AuthenticatedUser {
-
-    private final Long userId;
-
+public record AuthenticatedUser(
+        long userId,
+        String role
+) {
 }

--- a/src/main/java/com/upstage/devup/auth/config/SecurityConfig.java
+++ b/src/main/java/com/upstage/devup/auth/config/SecurityConfig.java
@@ -36,6 +36,11 @@ public class SecurityConfig {
             "/api/auth/signin",
     };
 
+    public static final String[] ADMIN_APIS = {
+            "/admin/**",
+            "/api/admin/**"
+    };
+
     public static final String[] SWAGGER_API = {
             "/swagger-ui.html",
             "/swagger-ui/**",
@@ -52,10 +57,10 @@ public class SecurityConfig {
     @Value("${spring.profiles.active:dev}")
     private String isDevProfile;
 
-    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     public SecurityConfig(JwtTokenProvider jwtTokenProvider) {
-        this.jwtTokenProvider = jwtTokenProvider;
+        this.jwtAuthenticationFilter = new JwtAuthenticationFilter(jwtTokenProvider);
     }
 
     @Bean
@@ -80,6 +85,7 @@ public class SecurityConfig {
 
         http
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(ADMIN_APIS).hasRole("ADMIN")  // 관리자 전용 API
                         .requestMatchers(STATIC_RESOURCES).permitAll()
                         .requestMatchers(PUBLIC_PAGES).permitAll()
                         .requestMatchers(PUBLIC_APIS).permitAll()
@@ -93,7 +99,7 @@ public class SecurityConfig {
 
         http
                 .addFilterBefore(
-                        new JwtAuthenticationFilter(jwtTokenProvider),
+                        jwtAuthenticationFilter,
                         UsernamePasswordAuthenticationFilter.class
                 )
                 .exceptionHandling(ex -> ex

--- a/src/main/java/com/upstage/devup/auth/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/upstage/devup/auth/config/jwt/JwtTokenProvider.java
@@ -30,15 +30,17 @@ public class JwtTokenProvider {
     /**
      * JWT 토큰 생성
      *
-     * @param userId 유저 고유 번호
-     * @return
+     * @param userId 사용자 ID
+     * @param role   사용자 권한
+     * @return 생성된 JWT 토큰
      */
-    public String generateToken(Long userId) {
+    public String generateToken(Long userId, String role) {
         Date now = new Date();
         Date expiredDate = new Date(System.currentTimeMillis() + jwtProperties.getExpiration());
 
         return Jwts.builder()
                 .setSubject(String.valueOf(userId))
+                .claim("role", role)
                 .setIssuer(jwtProperties.getIssuer())
                 .setIssuedAt(now)
                 .setExpiration(expiredDate)
@@ -87,8 +89,11 @@ public class JwtTokenProvider {
     public AuthenticatedUser getAuthenticatedUserFromJwtToken(String token) {
         try {
             Claims claims = parseToken(token);
+
             Long userId = Long.parseLong(claims.getSubject());
-            return new AuthenticatedUser(userId);
+            String role = claims.get("role", String.class);
+
+            return new AuthenticatedUser(userId, role);
         } catch (JwtException | IllegalArgumentException e) {
             log.warn("토큰에서 사용자 정보를 찾을 수 없음: {}", e.getMessage());
             return null;

--- a/src/main/java/com/upstage/devup/auth/controller/LogoutController.java
+++ b/src/main/java/com/upstage/devup/auth/controller/LogoutController.java
@@ -25,9 +25,10 @@ public class LogoutController {
 
     @PostMapping
     public ResponseEntity<?> logout(@AuthenticationPrincipal AuthenticatedUser user, HttpServletResponse response) {
-        log.info("로그아웃 요청 userId = {}", user.getUserId());
+        long userId = user.userId();
+        log.info("로그아웃 요청 userId = {}", userId);
 
-        if (user.getUserId() == null || user.getUserId() <= 0L) {
+        if (userId <= 0L) {
             throw new UnauthenticatedException("로그인이 필요합니다.");
         }
 

--- a/src/main/java/com/upstage/devup/auth/dto/SignUpResponseDto.java
+++ b/src/main/java/com/upstage/devup/auth/dto/SignUpResponseDto.java
@@ -16,4 +16,6 @@ public class SignUpResponseDto {
     private String nickname;
     private String email;
 
+    private String role;
+
 }

--- a/src/main/java/com/upstage/devup/auth/mapper/UserMapper.java
+++ b/src/main/java/com/upstage/devup/auth/mapper/UserMapper.java
@@ -2,6 +2,7 @@ package com.upstage.devup.auth.mapper;
 
 import com.upstage.devup.auth.dto.SignUpRequestDto;
 import com.upstage.devup.auth.dto.SignUpResponseDto;
+import com.upstage.devup.global.entity.Role;
 import com.upstage.devup.global.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -15,9 +16,10 @@ public class UserMapper {
 
     private final PasswordEncoder passwordEncoder;
 
-    public User toEntity(SignUpRequestDto request) {
+    public User toEntity(SignUpRequestDto request, Role role) {
 
         return User.builder()
+                .role(role)
                 .loginId(request.getLoginId())
                 .password(passwordEncoder.encode(request.getPassword()))
                 .nickname(request.getNickname())
@@ -32,6 +34,7 @@ public class UserMapper {
                 .loginId(entity.getLoginId())
                 .nickname(entity.getNickname())
                 .email(entity.getEmail())
+                .role(entity.getRole().getRoleName())
                 .build();
     }
 }

--- a/src/main/java/com/upstage/devup/auth/respository/RoleRepository.java
+++ b/src/main/java/com/upstage/devup/auth/respository/RoleRepository.java
@@ -1,0 +1,12 @@
+package com.upstage.devup.auth.respository;
+
+import com.upstage.devup.global.entity.Role;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RoleRepository extends JpaRepository<Role, Long> {
+    Optional<Role> findByRoleName(String roleUser);
+}

--- a/src/main/java/com/upstage/devup/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/upstage/devup/bookmark/controller/BookmarkController.java
@@ -28,7 +28,7 @@ public class BookmarkController {
             @AuthenticationPrincipal AuthenticatedUser user,
             @RequestParam Integer pageNumber
     ) {
-        BookmarksQueryDto result = bookmarkService.getBookmarks(user.getUserId(), pageNumber);
+        BookmarksQueryDto result = bookmarkService.getBookmarks(user.userId(), pageNumber);
         return ResponseEntity.ok(result);
     }
 
@@ -44,7 +44,7 @@ public class BookmarkController {
             @AuthenticationPrincipal AuthenticatedUser user,
             @PathVariable Long questionId
     ) {
-        BookmarkResponseDto result = bookmarkService.registerBookmark(user.getUserId(), questionId);
+        BookmarkResponseDto result = bookmarkService.registerBookmark(user.userId(), questionId);
         return ResponseEntity.ok(result);
     }
 
@@ -60,7 +60,7 @@ public class BookmarkController {
             @AuthenticationPrincipal AuthenticatedUser user,
             @PathVariable Long questionId
     ) {
-        BookmarkResponseDto result = bookmarkService.deleteBookmark(user.getUserId(), questionId);
+        BookmarkResponseDto result = bookmarkService.deleteBookmark(user.userId(), questionId);
         return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/com/upstage/devup/global/entity/Role.java
+++ b/src/main/java/com/upstage/devup/global/entity/Role.java
@@ -1,0 +1,33 @@
+package com.upstage.devup.global.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "roles")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Role {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 30)
+    private String roleName;
+
+    @Column(length = 100)
+    private String description;
+
+    @Column(nullable = false)
+    private LocalDateTime created_at;
+
+    private LocalDateTime modified_at;
+}

--- a/src/main/java/com/upstage/devup/global/entity/User.java
+++ b/src/main/java/com/upstage/devup/global/entity/User.java
@@ -20,6 +20,10 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "role_id", nullable = false)
+    private Role role;
+
     @Column(name = "login_id", nullable = false, unique = true)
     private String loginId;
 

--- a/src/main/java/com/upstage/devup/user/account/controller/UserAccountController.java
+++ b/src/main/java/com/upstage/devup/user/account/controller/UserAccountController.java
@@ -18,7 +18,7 @@ public class UserAccountController {
 
     @GetMapping
     public ResponseEntity<?> getUserAccount(@AuthenticationPrincipal AuthenticatedUser user) {
-        UserAccountDto result = userAccountService.getUserAccount(user.getUserId());
+        UserAccountDto result = userAccountService.getUserAccount(user.userId());
         return ResponseEntity.ok(result);
     }
 
@@ -28,7 +28,7 @@ public class UserAccountController {
             @RequestBody UserAccountUpdateDto userAccountUpdateDto) {
 
         System.out.println("UserAccountController.updateUserAccount");
-        UserAccountDto result = userAccountService.updateUserAccount(user.getUserId(), userAccountUpdateDto);
+        UserAccountDto result = userAccountService.updateUserAccount(user.userId(), userAccountUpdateDto);
         return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/com/upstage/devup/user/answer/controller/UserAnswerSaveController.java
+++ b/src/main/java/com/upstage/devup/user/answer/controller/UserAnswerSaveController.java
@@ -26,7 +26,7 @@ public class UserAnswerSaveController {
     public ResponseEntity<?> saveUserAnswer(
             @AuthenticationPrincipal AuthenticatedUser user,
             @RequestBody @Valid UserAnswerSaveRequest request) {
-        UserAnswerDetailDto result = userAnswerSaveService.saveUserAnswer(user.getUserId(), request);
+        UserAnswerDetailDto result = userAnswerSaveService.saveUserAnswer(user.userId(), request);
         return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/com/upstage/devup/user/history/controller/UserSolvedHistoryController.java
+++ b/src/main/java/com/upstage/devup/user/history/controller/UserSolvedHistoryController.java
@@ -27,7 +27,7 @@ public class UserSolvedHistoryController {
             @RequestParam Integer pageNumber) {
 
         Page<UserSolvedQuestionDto> results
-                = userSolvedHistoryService.getUserSolvedQuestions(user.getUserId(), pageNumber);
+                = userSolvedHistoryService.getUserSolvedQuestions(user.userId(), pageNumber);
 
         return ResponseEntity.ok(results);
     }

--- a/src/main/java/com/upstage/devup/user/wrong/controller/UserWrongNoteDeleteController.java
+++ b/src/main/java/com/upstage/devup/user/wrong/controller/UserWrongNoteDeleteController.java
@@ -30,7 +30,7 @@ public class UserWrongNoteDeleteController {
             @AuthenticationPrincipal AuthenticatedUser user,
             @PathVariable Long questionId
     ) {
-        userWrongNoteDeleteService.deleteWrongNote(user.getUserId(), questionId);
+        userWrongNoteDeleteService.deleteWrongNote(user.userId(), questionId);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/upstage/devup/user/wrong/controller/UserWrongNoteQueryController.java
+++ b/src/main/java/com/upstage/devup/user/wrong/controller/UserWrongNoteQueryController.java
@@ -30,7 +30,7 @@ public class UserWrongNoteQueryController {
         }
 
         Page<WrongNoteSummaryDto> result
-                = userWrongAnswerQueryService.getWrongNoteSummaries(user.getUserId(), pageNumber);
+                = userWrongAnswerQueryService.getWrongNoteSummaries(user.userId(), pageNumber);
 
         return ResponseEntity.ok(result);
     }

--- a/src/main/java/com/upstage/devup/web/MyPageViewController.java
+++ b/src/main/java/com/upstage/devup/web/MyPageViewController.java
@@ -25,7 +25,7 @@ public class MyPageViewController {
      */
     @GetMapping
     public String getMyPageView(@AuthenticationPrincipal AuthenticatedUser authenticatedUser, Model model) {
-        Long userId = authenticatedUser.getUserId();
+        long userId = authenticatedUser.userId();
 
         // 통계 정보 조회
         UserAnswerStatDto quizStat = userAnswerStatService.getUserAnswerStat(userId);

--- a/src/main/java/com/upstage/devup/web/QuestionController.java
+++ b/src/main/java/com/upstage/devup/web/QuestionController.java
@@ -64,7 +64,7 @@ public class QuestionController {
             @PathVariable Long questionId,
             Model model
     ) {
-        long userId = user == null ? 0L : user.getUserId();
+        long userId = user == null ? 0L : user.userId();
         QuestionDetailDto result = questionService.getQuestion(userId, questionId);
 
         model.addAttribute("question", result);

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -49,7 +49,8 @@ VALUES
     (2, 1, 'user2', '$2a$12$A5XbxYRC6WAEACzXW1QcpeKbr8NuFhcphfhACaXtRBjpWb2yACMvW', '사용자2', 'user2@devup.com', CURRENT_TIMESTAMP),
     (3, 1, 'user3', '$2a$12$7jpHtMMoVmHqQgw.mSgBPe8qnVXboRO3k920KCTbzChtHksJkfvo2', '사용자3', 'user3@devup.com', CURRENT_TIMESTAMP),
     (4, 1, 'user4', '$2a$12$0ZyGb/eUgu0JPRj8SAmTPuDQnJnV35cKT8ujJmBO0p73Nj/N/Sgw6', '사용자4', 'user4@devup.com', CURRENT_TIMESTAMP),
-    (5, 1, 'user5', '$2a$12$xvsNuP8HD4S5pb.k908Bru1.jNzBfRnkaaVBFX.RisuHOglvYCUJy', '사용자5', 'user5@devup.com', CURRENT_TIMESTAMP);
+    (5, 1, 'user5', '$2a$12$xvsNuP8HD4S5pb.k908Bru1.jNzBfRnkaaVBFX.RisuHOglvYCUJy', '사용자5', 'user5@devup.com', CURRENT_TIMESTAMP),
+    (6, 2, 'admin', '$2a$12$iLfO7X/iMCKIsNXGZMdlQu.QBwaHEHTj4QQkxA4VHGkP2.ij9L6NS', '관리자', 'admin@devup.com', CURRENT_TIMESTAMP);
 
 -- 질문 (questions)
 INSERT INTO questions

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -34,15 +34,22 @@ VALUES
     (2, 'MEDIUM'),
     (3, 'HARD');
 
+-- 권한 (roles)
+INSERT INTO roles
+    (id, role_name, description, created_at)
+VALUES
+    (1, 'ROLE_USER', '일반 사용자', CURRENT_TIMESTAMP),
+    (2, 'ROLE_ADMIN', '관리자', CURRENT_TIMESTAMP);
+
 -- 사용자 (users)
 INSERT INTO users
-    (id, login_id, password, nickname, email, created_at)
+    (id, role_id, login_id, password, nickname, email, created_at)
 VALUES
-    (1, 'user1', '$2a$12$L3hwEcWBtlbjNqbBO1Ukv.H2qYEprz6P9uylfT2RujWW9FiAEf9ve', '사용자1', 'user1@devup.com', CURRENT_TIMESTAMP),
-    (2, 'user2', '$2a$12$A5XbxYRC6WAEACzXW1QcpeKbr8NuFhcphfhACaXtRBjpWb2yACMvW', '사용자2', 'user2@devup.com', CURRENT_TIMESTAMP),
-    (3, 'user3', '$2a$12$7jpHtMMoVmHqQgw.mSgBPe8qnVXboRO3k920KCTbzChtHksJkfvo2', '사용자3', 'user3@devup.com', CURRENT_TIMESTAMP),
-    (4, 'user4', '$2a$12$0ZyGb/eUgu0JPRj8SAmTPuDQnJnV35cKT8ujJmBO0p73Nj/N/Sgw6', '사용자4', 'user4@devup.com', CURRENT_TIMESTAMP),
-    (5, 'user5', '$2a$12$xvsNuP8HD4S5pb.k908Bru1.jNzBfRnkaaVBFX.RisuHOglvYCUJy', '사용자5', 'user5@devup.com', CURRENT_TIMESTAMP);
+    (1, 1, 'user1', '$2a$12$L3hwEcWBtlbjNqbBO1Ukv.H2qYEprz6P9uylfT2RujWW9FiAEf9ve', '사용자1', 'user1@devup.com', CURRENT_TIMESTAMP),
+    (2, 1, 'user2', '$2a$12$A5XbxYRC6WAEACzXW1QcpeKbr8NuFhcphfhACaXtRBjpWb2yACMvW', '사용자2', 'user2@devup.com', CURRENT_TIMESTAMP),
+    (3, 1, 'user3', '$2a$12$7jpHtMMoVmHqQgw.mSgBPe8qnVXboRO3k920KCTbzChtHksJkfvo2', '사용자3', 'user3@devup.com', CURRENT_TIMESTAMP),
+    (4, 1, 'user4', '$2a$12$0ZyGb/eUgu0JPRj8SAmTPuDQnJnV35cKT8ujJmBO0p73Nj/N/Sgw6', '사용자4', 'user4@devup.com', CURRENT_TIMESTAMP),
+    (5, 1, 'user5', '$2a$12$xvsNuP8HD4S5pb.k908Bru1.jNzBfRnkaaVBFX.RisuHOglvYCUJy', '사용자5', 'user5@devup.com', CURRENT_TIMESTAMP);
 
 -- 질문 (questions)
 INSERT INTO questions

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -58,6 +58,16 @@ CREATE TABLE questions
     PRIMARY KEY (id)
 ); -- '기술 면접 질문'
 
+CREATE TABLE roles
+(
+    id          BIGINT       NOT NULL AUTO_INCREMENT,
+    role_name   VARCHAR(30)  NOT NULL COMMENT '권한 이름',
+    description VARCHAR(100) NULL     COMMENT '권한 설명',
+    created_at  TIMESTAMP    NOT NULL COMMENT '등록일',
+    modified_at TIMESTAMP    NULL     COMMENT '수정일',
+    PRIMARY KEY (id)
+); -- '사용자 권한'
+
 CREATE TABLE user_answer_stats
 (
     id              BIGINT    NOT NULL AUTO_INCREMENT,
@@ -87,6 +97,7 @@ ALTER TABLE user_answers
 CREATE TABLE users
 (
     id          BIGINT       NOT NULL AUTO_INCREMENT,
+    role_id     BIGINT       NOT NULL,
     login_id    VARCHAR(100) NOT NULL,
     password    VARCHAR(255) NOT NULL,
     nickname    VARCHAR(100) NOT NULL,
@@ -173,3 +184,8 @@ ALTER TABLE user_answer_stats
     ADD CONSTRAINT FK_questions_TO_user_answer_stats
         FOREIGN KEY (question_id)
             REFERENCES questions (id);
+
+ALTER TABLE users
+    ADD CONSTRAINT FK_roles_TO_users
+        FOREIGN KEY (role_id)
+            REFERENCES roles (id);

--- a/src/test/java/com/upstage/devup/Util.java
+++ b/src/test/java/com/upstage/devup/Util.java
@@ -1,0 +1,25 @@
+package com.upstage.devup;
+
+import com.upstage.devup.auth.config.AuthenticatedUser;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import java.util.List;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+
+public class Util {
+
+    private Util() {}
+
+    public static RequestPostProcessor getAuthentication(long userId, String role) {
+        AuthenticatedUser user = new AuthenticatedUser(userId, role);
+
+        return authentication(new UsernamePasswordAuthenticationToken(
+                user,
+                null,
+                List.of(new SimpleGrantedAuthority(user.role()))
+        ));
+    }
+}

--- a/src/test/java/com/upstage/devup/auth/controller/LogoutControllerTest.java
+++ b/src/test/java/com/upstage/devup/auth/controller/LogoutControllerTest.java
@@ -1,6 +1,5 @@
 package com.upstage.devup.auth.controller;
 
-import com.upstage.devup.auth.config.AuthenticatedUser;
 import com.upstage.devup.auth.config.SecurityConfig;
 import com.upstage.devup.auth.config.jwt.JwtTokenProvider;
 import com.upstage.devup.global.properties.CookieProperties;
@@ -14,15 +13,12 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultMatcher;
-import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
+import static com.upstage.devup.Util.getAuthentication;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.anonymous;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -37,6 +33,7 @@ class LogoutControllerTest {
     @MockitoBean
     private JwtTokenProvider jwtTokenProvider;
 
+    private static final String ROLE_USER = "ROLE_USER";
     private static final String URI_TEMPLATE = "/api/auth/logout";
 
     @Test
@@ -47,7 +44,7 @@ class LogoutControllerTest {
 
         // when & then
         mockMvc.perform(post(URI_TEMPLATE)
-                        .with(getAuthentication(userId)))
+                        .with(getAuthentication(userId, ROLE_USER)))
                 .andExpect(status().isOk())
                 .andExpect(compareStringInHeader("accessToken="))
                 .andExpect(compareStringInHeader("Max-Age=0"))
@@ -75,7 +72,7 @@ class LogoutControllerTest {
 
         // when & then
         mockMvc.perform(post(URI_TEMPLATE)
-                        .with(getAuthentication(userId)))
+                        .with(getAuthentication(userId, ROLE_USER)))
                 .andExpect(status().isUnauthorized());
     }
 
@@ -84,13 +81,6 @@ class LogoutControllerTest {
                 .string(
                         HttpHeaders.SET_COOKIE, Matchers.containsString(subString)
                 );
-    }
-
-    private RequestPostProcessor getAuthentication(Long userId) {
-        AuthenticatedUser user = new AuthenticatedUser(userId);
-        Authentication auth = new UsernamePasswordAuthenticationToken(user, null, null);
-
-        return authentication(auth);
     }
 
 }

--- a/src/test/java/com/upstage/devup/auth/service/UserAuthServiceSignInTest.java
+++ b/src/test/java/com/upstage/devup/auth/service/UserAuthServiceSignInTest.java
@@ -10,11 +10,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
+@Transactional
 public class UserAuthServiceSignInTest {
 
     @Autowired

--- a/src/test/java/com/upstage/devup/bookmark/controller/BookmarkControllerTest.java
+++ b/src/test/java/com/upstage/devup/bookmark/controller/BookmarkControllerTest.java
@@ -1,6 +1,5 @@
 package com.upstage.devup.bookmark.controller;
 
-import com.upstage.devup.auth.config.AuthenticatedUser;
 import com.upstage.devup.auth.config.SecurityConfig;
 import com.upstage.devup.auth.config.jwt.JwtTokenProvider;
 import com.upstage.devup.bookmark.dto.BookmarkDetails;
@@ -17,19 +16,16 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 
+import static com.upstage.devup.Util.getAuthentication;
 import static org.mockito.Mockito.*;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -46,11 +42,7 @@ class BookmarkControllerTest {
     @MockitoBean
     private JwtTokenProvider jwtTokenProvider;
 
-    private RequestPostProcessor getAuthentication(Long userId) {
-        AuthenticatedUser user = new AuthenticatedUser(userId);
-        Authentication auth = new UsernamePasswordAuthenticationToken(user, null, null);
-        return authentication(auth);
-    }
+    private static final String ROLE_USER = "ROLE_USER";
 
     @Nested
     @DisplayName("북마크 조회")
@@ -86,7 +78,7 @@ class BookmarkControllerTest {
 
                 // when & then
                 mockMvc.perform(get(URL_TEMPLATE)
-                                .with(getAuthentication(userId))
+                                .with(getAuthentication(userId, ROLE_USER))
                                 .param("pageNumber", String.valueOf(pageNumber)))
                         .andExpect(status().isOk())
                         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -115,7 +107,7 @@ class BookmarkControllerTest {
 
                 // when & then
                 mockMvc.perform(get(URL_TEMPLATE)
-                                .with(getAuthentication(userId))
+                                .with(getAuthentication(userId, ROLE_USER))
                                 .param("pageNumber", String.valueOf(pageNumber)))
                         .andExpect(status().isOk())
                         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -146,7 +138,7 @@ class BookmarkControllerTest {
 
                 // when & then
                 mockMvc.perform(get(URL_TEMPLATE)
-                                .with(getAuthentication(userId))
+                                .with(getAuthentication(userId, ROLE_USER))
                                 .param("pageNumber", String.valueOf(pageNumber)))
                         .andExpect(status().isOk())
                         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -195,7 +187,7 @@ class BookmarkControllerTest {
 
                 mockMvc.perform(
                                 post(URL_TEMPLATE + questionId)
-                                        .with(getAuthentication(userId)))
+                                        .with(getAuthentication(userId, ROLE_USER)))
                         .andExpect(status().isOk())
                         .andExpect(content().contentType("application/json"))
                         .andExpect(jsonPath("$.userId").value(userId))
@@ -232,7 +224,7 @@ class BookmarkControllerTest {
 
                 // when & then
                 mockMvc.perform(post(URL_TEMPLATE + questionId)
-                                .with(getAuthentication(userId)))
+                                .with(getAuthentication(userId, ROLE_USER)))
                         .andExpect(status().isNotFound());
             }
         }
@@ -272,7 +264,7 @@ class BookmarkControllerTest {
                         .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
 
                 mockMvc.perform(delete(URL_TEMPLATE + questionId)
-                                .with(getAuthentication(userId)))
+                                .with(getAuthentication(userId, ROLE_USER)))
                         .andExpect(status().isOk())
                         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.userId").value(userId))
@@ -309,7 +301,7 @@ class BookmarkControllerTest {
 
                 // when & then
                 mockMvc.perform(delete(URL_TEMPLATE + questionId)
-                                .with(getAuthentication(userId)))
+                                .with(getAuthentication(userId, ROLE_USER)))
                         .andExpect(status().isNotFound())
                         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code").value("NOT_FOUND"))

--- a/src/test/java/com/upstage/devup/bookmark/service/BookmarkServiceTest.java
+++ b/src/test/java/com/upstage/devup/bookmark/service/BookmarkServiceTest.java
@@ -45,6 +45,7 @@ class BookmarkServiceTest {
     @BeforeEach
     public void beforeEach() {
         User user = userAccountRepository.save(User.builder()
+                .role(Role.builder().id(1L).build())
                 .loginId("user1234")
                 .password("pass1234")
                 .nickname("nickname1234")
@@ -69,6 +70,7 @@ class BookmarkServiceTest {
     public class BookmarksQuery {
 
         private final int totalElements = 12;
+
         @BeforeEach
         public void beforeEach() {
             User user = userAccountRepository.findById(userId)

--- a/src/test/java/com/upstage/devup/question/service/QuestionServiceTest.java
+++ b/src/test/java/com/upstage/devup/question/service/QuestionServiceTest.java
@@ -122,6 +122,7 @@ class QuestionServiceTest {
         @BeforeEach
         public void beforeEach() {
             user = userAccountRepository.save(User.builder()
+                    .role(Role.builder().id(1L).build())
                     .loginId("test")
                     .password("1234")
                     .nickname("test_user")

--- a/src/test/java/com/upstage/devup/user/account/controller/UserAccountControllerTest.java
+++ b/src/test/java/com/upstage/devup/user/account/controller/UserAccountControllerTest.java
@@ -1,6 +1,5 @@
 package com.upstage.devup.user.account.controller;
 
-import com.upstage.devup.auth.config.AuthenticatedUser;
 import com.upstage.devup.auth.config.SecurityConfig;
 import com.upstage.devup.auth.config.jwt.JwtTokenProvider;
 import com.upstage.devup.global.exception.EntityNotFoundException;
@@ -12,15 +11,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
+import static com.upstage.devup.Util.getAuthentication;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.when;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -37,6 +33,7 @@ class UserAccountControllerTest {
     @MockitoBean
     private UserAccountService userAccountService;
 
+    private static final String ROLE_USER = "ROLE_USER";
     private static final String urlTemplate = "/api/user/account";
 
     @Test
@@ -57,7 +54,7 @@ class UserAccountControllerTest {
 
         // when & then
         mockMvc.perform(get(urlTemplate)
-                        .with(getAuthentication(userId)))
+                        .with(getAuthentication(userId, ROLE_USER)))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.userId").value(userId.toString()))
@@ -85,17 +82,10 @@ class UserAccountControllerTest {
 
         // when & then
         mockMvc.perform(get(urlTemplate)
-                        .with(getAuthentication(userId)))
+                        .with(getAuthentication(userId, ROLE_USER)))
                 .andExpect(status().isNotFound())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.message").value(errorMessage));
-    }
-
-    private RequestPostProcessor getAuthentication(Long userId) {
-        AuthenticatedUser user = new AuthenticatedUser(userId);
-        Authentication auth = new UsernamePasswordAuthenticationToken(user, null, null);
-
-        return authentication(auth);
     }
 
 }

--- a/src/test/java/com/upstage/devup/user/answer/controller/UserAnswerSaveControllerTest.java
+++ b/src/test/java/com/upstage/devup/user/answer/controller/UserAnswerSaveControllerTest.java
@@ -1,7 +1,6 @@
 package com.upstage.devup.user.answer.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.upstage.devup.auth.config.AuthenticatedUser;
 import com.upstage.devup.auth.config.SecurityConfig;
 import com.upstage.devup.auth.config.jwt.JwtTokenProvider;
 import com.upstage.devup.global.exception.EntityNotFoundException;
@@ -15,20 +14,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 
+import static com.upstage.devup.Util.getAuthentication;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -50,13 +46,8 @@ class UserAnswerSaveControllerTest {
     @MockitoBean
     private JwtTokenProvider jwtTokenProvider;
 
+    private static final String ROLE_USER = "ROLE_USER";
     private static final String URI_TEMPLATE = "/api/user/answer";
-
-    private RequestPostProcessor getAuthentication(Long userId) {
-        AuthenticatedUser user = new AuthenticatedUser(userId);
-        Authentication auth = new UsernamePasswordAuthenticationToken(user, null, null);
-        return authentication(auth);
-    }
 
     @Nested
     @DisplayName("성공 케이스")
@@ -99,7 +90,7 @@ class UserAnswerSaveControllerTest {
                     .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
 
             mockMvc.perform(post(URI_TEMPLATE)
-                            .with(getAuthentication(userId))
+                            .with(getAuthentication(userId, ROLE_USER))
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isOk())
@@ -158,7 +149,7 @@ class UserAnswerSaveControllerTest {
 
             // when & then
             mockMvc.perform(post(URI_TEMPLATE)
-                            .with(getAuthentication(userId))
+                            .with(getAuthentication(userId, ROLE_USER))
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andDo(print())
@@ -176,7 +167,7 @@ class UserAnswerSaveControllerTest {
 
             // when & then
             mockMvc.perform(post(URI_TEMPLATE)
-                            .with(getAuthentication(userId))
+                            .with(getAuthentication(userId, ROLE_USER))
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(""))
                     .andExpect(status().isBadRequest());
@@ -194,7 +185,7 @@ class UserAnswerSaveControllerTest {
 
             // when & then
             mockMvc.perform(post(URI_TEMPLATE)
-                            .with(getAuthentication(userId))
+                            .with(getAuthentication(userId, ROLE_USER))
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isBadRequest());
@@ -216,7 +207,7 @@ class UserAnswerSaveControllerTest {
 
             // when & then
             mockMvc.perform(post(URI_TEMPLATE)
-                            .with(getAuthentication(userId))
+                            .with(getAuthentication(userId, ROLE_USER))
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isNotFound())
@@ -237,7 +228,7 @@ class UserAnswerSaveControllerTest {
 
             // when & then
             mockMvc.perform(post(URI_TEMPLATE)
-                            .with(getAuthentication(userId))
+                            .with(getAuthentication(userId, ROLE_USER))
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andDo(print())
@@ -257,7 +248,7 @@ class UserAnswerSaveControllerTest {
 
             // when & then
             mockMvc.perform(post(URI_TEMPLATE)
-                            .with(getAuthentication(userId))
+                            .with(getAuthentication(userId, ROLE_USER))
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andDo(print())
@@ -277,7 +268,7 @@ class UserAnswerSaveControllerTest {
 
             // when & then
             mockMvc.perform(post(URI_TEMPLATE)
-                            .with(getAuthentication(userId))
+                            .with(getAuthentication(userId, ROLE_USER))
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andDo(print())
@@ -296,7 +287,7 @@ class UserAnswerSaveControllerTest {
 
             // when & then
             mockMvc.perform(post(URI_TEMPLATE)
-                            .with(getAuthentication(userId))
+                            .with(getAuthentication(userId, ROLE_USER))
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andDo(print())

--- a/src/test/java/com/upstage/devup/user/wrong/controller/UserWrongNoteDeleteControllerTest.java
+++ b/src/test/java/com/upstage/devup/user/wrong/controller/UserWrongNoteDeleteControllerTest.java
@@ -1,6 +1,5 @@
 package com.upstage.devup.user.wrong.controller;
 
-import com.upstage.devup.auth.config.AuthenticatedUser;
 import com.upstage.devup.auth.config.SecurityConfig;
 import com.upstage.devup.auth.config.jwt.JwtTokenProvider;
 import com.upstage.devup.global.exception.EntityNotFoundException;
@@ -8,19 +7,14 @@ import com.upstage.devup.user.wrong.service.UserWrongNoteDeleteService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
+import static com.upstage.devup.Util.getAuthentication;
 import static org.mockito.Mockito.doThrow;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -38,13 +32,8 @@ class UserWrongNoteDeleteControllerTest {
     @MockitoBean
     private UserWrongNoteDeleteService userWrongNoteDeleteService;
 
+    private static final String ROLE_USER = "ROLE_USER";
     private static final String URI_TEMPLATE = "/api/wrong/";
-
-    private RequestPostProcessor getAuthentication(Long userId) {
-        AuthenticatedUser user = new AuthenticatedUser(userId);
-        Authentication auth = new UsernamePasswordAuthenticationToken(user, null, null);
-        return authentication(auth);
-    }
 
     @Nested
     @DisplayName("성공 테스트")
@@ -59,7 +48,7 @@ class UserWrongNoteDeleteControllerTest {
 
             // when & then
             mockMvc.perform(delete(URI_TEMPLATE + questionId)
-                            .with(getAuthentication(userId)))
+                            .with(getAuthentication(userId, ROLE_USER)))
                     .andDo(print())
                     .andExpect(status().isOk());
         }
@@ -93,7 +82,7 @@ class UserWrongNoteDeleteControllerTest {
 
             // when & then
             mockMvc.perform(delete(URI_TEMPLATE + questionId)
-                            .with(getAuthentication(userId)))
+                            .with(getAuthentication(userId, ROLE_USER)))
                     .andExpect(status().isNotFound());
         }
     }

--- a/src/test/java/com/upstage/devup/user/wrong/controller/UserWrongNoteQueryControllerTest.java
+++ b/src/test/java/com/upstage/devup/user/wrong/controller/UserWrongNoteQueryControllerTest.java
@@ -1,6 +1,5 @@
 package com.upstage.devup.user.wrong.controller;
 
-import com.upstage.devup.auth.config.AuthenticatedUser;
 import com.upstage.devup.auth.config.SecurityConfig;
 import com.upstage.devup.auth.config.jwt.JwtTokenProvider;
 import com.upstage.devup.user.statistics.dto.WrongNoteSummaryDto;
@@ -15,18 +14,15 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static com.upstage.devup.Util.getAuthentication;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -47,6 +43,8 @@ class UserWrongNoteQueryControllerTest {
 
     @MockitoBean
     private JwtTokenProvider jwtTokenProvider;
+
+    private static final String ROLE_USER = "ROLE_USER";
 
     @Test
     @DisplayName("오답 노트 목록 조회 성공")
@@ -76,7 +74,7 @@ class UserWrongNoteQueryControllerTest {
         // when & then
         mockMvc.perform(get("/api/wrong")
                         .param("pageNumber", String.valueOf(pageNumber))
-                        .with(getAuthentication(userId)))
+                        .with(getAuthentication(userId, ROLE_USER)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content").isArray())
                 .andExpect(jsonPath("$.content[0].userId").value(String.valueOf(userId)))
@@ -84,11 +82,5 @@ class UserWrongNoteQueryControllerTest {
                 .andExpect(jsonPath("$.content[0].title").value(String.valueOf(dto.getTitle())))
                 .andExpect(jsonPath("$.content[0].category").value(String.valueOf(dto.getCategory())))
                 .andExpect(jsonPath("$.content[0].level").value(String.valueOf(dto.getLevel())));
-    }
-
-    private RequestPostProcessor getAuthentication(Long userId) {
-        AuthenticatedUser user = new AuthenticatedUser(userId);
-        Authentication auth = new UsernamePasswordAuthenticationToken(user, null, null);
-        return authentication(auth);
     }
 }

--- a/src/test/java/com/upstage/devup/user/wrong/service/UserWrongNoteDeleteServiceTest.java
+++ b/src/test/java/com/upstage/devup/user/wrong/service/UserWrongNoteDeleteServiceTest.java
@@ -45,6 +45,7 @@ class UserWrongNoteDeleteServiceTest {
     @BeforeEach
     public void beforeEach() {
         User user = userAccountRepository.save(User.builder()
+                .role(Role.builder().id(1L).build())
                 .loginId("user1234")
                 .password("pass1234")
                 .nickname("nickname1234")

--- a/src/test/java/com/upstage/devup/web/AuthViewControllerTest.java
+++ b/src/test/java/com/upstage/devup/web/AuthViewControllerTest.java
@@ -1,6 +1,5 @@
 package com.upstage.devup.web;
 
-import com.upstage.devup.auth.config.AuthenticatedUser;
 import com.upstage.devup.auth.config.SecurityConfig;
 import com.upstage.devup.auth.config.jwt.JwtTokenProvider;
 import org.junit.jupiter.api.DisplayName;
@@ -8,13 +7,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static com.upstage.devup.Util.getAuthentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
@@ -28,6 +24,8 @@ class AuthViewControllerTest {
 
     @MockitoBean
     private JwtTokenProvider jwtTokenProvider;
+
+    private static final String ROLE_USER = "ROLE_USER";
 
     private static final String URI_TEMPLATE = "/auth/signin";
 
@@ -50,14 +48,8 @@ class AuthViewControllerTest {
 
         // when & then
         mockMvc.perform(get(URI_TEMPLATE)
-                        .with(getAuthentication(userId)))
+                        .with(getAuthentication(userId, ROLE_USER)))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(view().name("redirect:/mypage"));
-    }
-
-    private RequestPostProcessor getAuthentication(Long userId) {
-        AuthenticatedUser user = new AuthenticatedUser(userId);
-        Authentication auth = new UsernamePasswordAuthenticationToken(user, null, null);
-        return authentication(auth);
     }
 }


### PR DESCRIPTION
## 작업 내용

### 사용자 권한 추가(`role`)
- `roles` 테이블을 추가해 사용자 권한을 관리
- 일반 사용자(`ROLE_USER`), 관리자(`ROLE_ADMIN`) 권한 추가
- `data.sql`에 관리자 계정(`admin`) 추가
- `Role` 엔티티: `roles` 테이블과 매핑
- `User` 엔티티와 `Role` 엔티티 연관 관계 설정

### JWT 토큰 기능 수정
- JWT 토큰의 `claim`에 사용자 권한 추가
- JWT Filter에서 사용자 권한 읽어오는 기능 추가

### 관리자 전용 API를 예외 경로로 등록
- `/admin/**`, `/api/admin/**`는 관리자 권한(`ROLE_ADMIN`)이 있는 사용자만 접근 가능하도록 설정
- `SecurityConfig.class`에 해당 사항 반영

### `AuthenticatedUser`를 `record`로 변경
- `AuthenticatedUser`에 임의의 수정이 이뤄지지 않도록 하기 위해 `record`로 변경
- 변경에 따른 코드 수정

### `getAuthentication ` 메서드를 `Util` 클래스로 분리
- 테스트 코드에서 반복적으로 사용되는 메서드를 분리해 다른 코드에서도 쉽게 사용하도록 분리