### PR TITLE
feat: 카테고리 CRUD 기능 및 API 구현

### DIFF
--- a/src/main/java/com/upstage/devup/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/upstage/devup/bookmark/repository/BookmarkRepository.java
@@ -19,7 +19,7 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, BookmarkId> 
 
     @Query("""
         SELECT new com.upstage.devup.bookmark.dto.BookmarkDetails(
-                q.id, q.title, c.category, l.level, b.createdAt
+                q.id, q.title, c.categoryName, l.level, b.createdAt
                 )
                 FROM Bookmark b
                 JOIN b.question q

--- a/src/main/java/com/upstage/devup/category/controller/CategoryController.java
+++ b/src/main/java/com/upstage/devup/category/controller/CategoryController.java
@@ -1,13 +1,12 @@
 package com.upstage.devup.category.controller;
 
+import com.upstage.devup.category.dto.CategoryAddRequest;
 import com.upstage.devup.category.dto.CategoryDto;
 import com.upstage.devup.category.service.CategoryService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/admin/category")
@@ -15,6 +14,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class CategoryController {
 
     private final CategoryService categoryService;
+
+    @PostMapping
+    public ResponseEntity<CategoryDto> createCategory(@Valid @RequestBody CategoryAddRequest request) {
+
+        return ResponseEntity.ok(
+                categoryService.addCategory(request)
+        );
+    }
 
     @DeleteMapping("/{categoryId}")
     public ResponseEntity<CategoryDto> deleteCategory(@PathVariable Long categoryId) {

--- a/src/main/java/com/upstage/devup/category/controller/CategoryController.java
+++ b/src/main/java/com/upstage/devup/category/controller/CategoryController.java
@@ -1,0 +1,26 @@
+package com.upstage.devup.category.controller;
+
+import com.upstage.devup.category.dto.CategoryDto;
+import com.upstage.devup.category.service.CategoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin/category")
+@RequiredArgsConstructor
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @DeleteMapping("/{categoryId}")
+    public ResponseEntity<CategoryDto> deleteCategory(@PathVariable Long categoryId) {
+
+        return ResponseEntity.ok(
+                categoryService.deleteCategory(categoryId)
+        );
+    }
+}

--- a/src/main/java/com/upstage/devup/category/controller/CategoryController.java
+++ b/src/main/java/com/upstage/devup/category/controller/CategoryController.java
@@ -2,6 +2,7 @@ package com.upstage.devup.category.controller;
 
 import com.upstage.devup.category.dto.CategoryAddRequest;
 import com.upstage.devup.category.dto.CategoryDto;
+import com.upstage.devup.category.dto.CategoryUpdateRequest;
 import com.upstage.devup.category.service.CategoryService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,14 @@ public class CategoryController {
 
         return ResponseEntity.ok(
                 categoryService.addCategory(request)
+        );
+    }
+
+    @PatchMapping
+    public ResponseEntity<CategoryDto> updateCategory(@Valid @RequestBody CategoryUpdateRequest request) {
+
+        return ResponseEntity.ok(
+                categoryService.updateCategory(request)
         );
     }
 

--- a/src/main/java/com/upstage/devup/category/dto/CategoryAddRequest.java
+++ b/src/main/java/com/upstage/devup/category/dto/CategoryAddRequest.java
@@ -1,0 +1,13 @@
+package com.upstage.devup.category.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CategoryAddRequest(
+        @NotBlank(message = "카테고리를 입력해 주세요.")
+        String category,
+
+        @NotBlank(message = "색상을 입력해 주세요.")
+        String color
+) {
+
+}

--- a/src/main/java/com/upstage/devup/category/dto/CategoryAddRequest.java
+++ b/src/main/java/com/upstage/devup/category/dto/CategoryAddRequest.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 
 public record CategoryAddRequest(
         @NotBlank(message = "카테고리를 입력해 주세요.")
-        String category,
+        String categoryName,
 
         @NotBlank(message = "색상을 입력해 주세요.")
         String color

--- a/src/main/java/com/upstage/devup/category/dto/CategoryDto.java
+++ b/src/main/java/com/upstage/devup/category/dto/CategoryDto.java
@@ -1,0 +1,9 @@
+package com.upstage.devup.category.dto;
+
+public record CategoryDto(
+        Long id,
+        String categoryName,
+        String color
+) {
+}
+

--- a/src/main/java/com/upstage/devup/category/dto/CategoryPageDto.java
+++ b/src/main/java/com/upstage/devup/category/dto/CategoryPageDto.java
@@ -1,0 +1,11 @@
+package com.upstage.devup.category.dto;
+
+import com.upstage.devup.global.domain.dto.PageDto;
+import org.springframework.data.domain.Page;
+
+public class CategoryPageDto extends PageDto<CategoryDto> {
+
+    public CategoryPageDto(Page<CategoryDto> page) {
+        super(page);
+    }
+}

--- a/src/main/java/com/upstage/devup/category/dto/CategoryUpdateRequest.java
+++ b/src/main/java/com/upstage/devup/category/dto/CategoryUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.upstage.devup.category.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CategoryUpdateRequest(
+
+        @NotNull
+        Long categoryId,
+
+        @NotBlank(message = "카테고리를 입력해 주세요.")
+        String category,
+
+        @NotBlank(message = "색상을 입력해 주세요.")
+        String color
+) {
+}

--- a/src/main/java/com/upstage/devup/category/dto/CategoryUpdateRequest.java
+++ b/src/main/java/com/upstage/devup/category/dto/CategoryUpdateRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotNull;
 
 public record CategoryUpdateRequest(
 
-        @NotNull
+        @NotNull(message = "변경할 카테고리를 선택해 주세요.")
         Long categoryId,
 
         @NotBlank(message = "카테고리를 입력해 주세요.")

--- a/src/main/java/com/upstage/devup/category/mapper/CategoryMapper.java
+++ b/src/main/java/com/upstage/devup/category/mapper/CategoryMapper.java
@@ -1,0 +1,28 @@
+package com.upstage.devup.category.mapper;
+
+import com.upstage.devup.category.dto.CategoryAddRequest;
+import com.upstage.devup.category.dto.CategoryDto;
+import com.upstage.devup.global.entity.Category;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CategoryMapper {
+
+    private CategoryMapper() {
+    }
+
+    public Category toEntity(CategoryAddRequest request) {
+        return Category.builder()
+                .category(request.category())
+                .color(request.color())
+                .build();
+    }
+
+    public CategoryDto toCategoryDto(Category entity) {
+        return new CategoryDto(
+                entity.getId(),
+                entity.getCategory(),
+                entity.getColor()
+        );
+    }
+}

--- a/src/main/java/com/upstage/devup/category/mapper/CategoryMapper.java
+++ b/src/main/java/com/upstage/devup/category/mapper/CategoryMapper.java
@@ -13,7 +13,7 @@ public class CategoryMapper {
 
     public Category toEntity(CategoryAddRequest request) {
         return Category.builder()
-                .category(request.category())
+                .categoryName(request.category())
                 .color(request.color())
                 .build();
     }
@@ -21,7 +21,7 @@ public class CategoryMapper {
     public CategoryDto toCategoryDto(Category entity) {
         return new CategoryDto(
                 entity.getId(),
-                entity.getCategory(),
+                entity.getCategoryName(),
                 entity.getColor()
         );
     }

--- a/src/main/java/com/upstage/devup/category/mapper/CategoryMapper.java
+++ b/src/main/java/com/upstage/devup/category/mapper/CategoryMapper.java
@@ -13,7 +13,7 @@ public class CategoryMapper {
 
     public Category toEntity(CategoryAddRequest request) {
         return Category.builder()
-                .categoryName(request.category())
+                .categoryName(request.categoryName())
                 .color(request.color())
                 .build();
     }

--- a/src/main/java/com/upstage/devup/category/repository/CategoryRepository.java
+++ b/src/main/java/com/upstage/devup/category/repository/CategoryRepository.java
@@ -1,0 +1,11 @@
+package com.upstage.devup.category.repository;
+
+import com.upstage.devup.global.entity.Category;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+    boolean existsByCategory(@NotBlank(message = "카테고리를 입력해 주세요.") String category);
+}

--- a/src/main/java/com/upstage/devup/category/repository/CategoryRepository.java
+++ b/src/main/java/com/upstage/devup/category/repository/CategoryRepository.java
@@ -1,11 +1,10 @@
 package com.upstage.devup.category.repository;
 
 import com.upstage.devup.global.entity.Category;
-import jakarta.validation.constraints.NotBlank;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
-    boolean existsByCategory(@NotBlank(message = "카테고리를 입력해 주세요.") String category);
+    boolean existsByCategoryName(String categoryName);
 }

--- a/src/main/java/com/upstage/devup/category/service/CategoryService.java
+++ b/src/main/java/com/upstage/devup/category/service/CategoryService.java
@@ -30,7 +30,7 @@ public class CategoryService {
      */
     @Transactional
     public CategoryDto addCategory(CategoryAddRequest request) {
-        if (checkCategoryNameIsInUse(request.category())) {
+        if (checkCategoryNameIsInUse(request.categoryName())) {
             throw new DuplicatedResourceException("이미 존재하는 카테고리입니다.");
         }
 

--- a/src/main/java/com/upstage/devup/category/service/CategoryService.java
+++ b/src/main/java/com/upstage/devup/category/service/CategoryService.java
@@ -1,0 +1,49 @@
+package com.upstage.devup.category.service;
+
+import com.upstage.devup.category.dto.CategoryAddRequest;
+import com.upstage.devup.category.dto.CategoryDto;
+import com.upstage.devup.category.mapper.CategoryMapper;
+import com.upstage.devup.category.repository.CategoryRepository;
+import com.upstage.devup.global.exception.DuplicatedResourceException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+    private final CategoryMapper categoryMapper;
+
+    // 카테고리 저장
+
+    /**
+     * 카테고리 저장
+     *
+     * @param request 저장할 카테고리 정보
+     * @return 저장된 카테고리 정보
+     */
+    @Transactional
+    public CategoryDto addCategory(CategoryAddRequest request) {
+        if (categoryRepository.existsByCategory(request.category())) {
+            throw new DuplicatedResourceException("이미 존재하는 카테고리입니다.");
+        }
+
+        try {
+            return categoryMapper.toCategoryDto(
+                    categoryRepository.save(
+                            categoryMapper.toEntity(request)
+                    )
+            );
+        } catch (DataIntegrityViolationException exception) {
+            throw new DuplicatedResourceException("이미 존재하는 카테고리입니다.");
+        }
+    }
+
+    // TODO: 카테고리 수정
+    // TODO: 카테고리 삭제
+}

--- a/src/main/java/com/upstage/devup/category/service/CategoryService.java
+++ b/src/main/java/com/upstage/devup/category/service/CategoryService.java
@@ -62,7 +62,7 @@ public class CategoryService {
         Category entity = categoryRepository.findById(request.categoryId())
                 .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 카테고리입니다."));
 
-        entity.setCategory(request.category());
+        entity.setCategoryName(request.category());
         entity.setColor(request.color());
 
         try {
@@ -83,6 +83,6 @@ public class CategoryService {
      * @return true: 중복 값 있음, false: 중복 값 없음
      */
     private boolean checkCategoryNameIsInUse(String categoryName) {
-        return categoryRepository.existsByCategory(categoryName);
+        return categoryRepository.existsByCategoryName(categoryName);
     }
 }

--- a/src/main/java/com/upstage/devup/category/service/CategoryService.java
+++ b/src/main/java/com/upstage/devup/category/service/CategoryService.java
@@ -2,9 +2,12 @@ package com.upstage.devup.category.service;
 
 import com.upstage.devup.category.dto.CategoryAddRequest;
 import com.upstage.devup.category.dto.CategoryDto;
+import com.upstage.devup.category.dto.CategoryUpdateRequest;
 import com.upstage.devup.category.mapper.CategoryMapper;
 import com.upstage.devup.category.repository.CategoryRepository;
+import com.upstage.devup.global.entity.Category;
 import com.upstage.devup.global.exception.DuplicatedResourceException;
+import com.upstage.devup.global.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -19,8 +22,6 @@ public class CategoryService {
     private final CategoryRepository categoryRepository;
     private final CategoryMapper categoryMapper;
 
-    // 카테고리 저장
-
     /**
      * 카테고리 저장
      *
@@ -29,7 +30,7 @@ public class CategoryService {
      */
     @Transactional
     public CategoryDto addCategory(CategoryAddRequest request) {
-        if (categoryRepository.existsByCategory(request.category())) {
+        if (checkCategoryNameIsInUse(request.category())) {
             throw new DuplicatedResourceException("이미 존재하는 카테고리입니다.");
         }
 
@@ -44,6 +45,44 @@ public class CategoryService {
         }
     }
 
-    // TODO: 카테고리 수정
+    /**
+     * 카테고리 수정하기
+     *
+     * @param request 수정할 카테고리 정보
+     * @return 수정된 카테고리 정보
+     * @throws DuplicatedResourceException 중복된 카테고리 이름을 사용하는 경우 발생
+     * @throws EntityNotFoundException     수정하려는 카테고리가 없는 경우
+     */
+    @Transactional
+    public CategoryDto updateCategory(CategoryUpdateRequest request) {
+        if (checkCategoryNameIsInUse(request.category())) {
+            throw new DuplicatedResourceException("이미 존재하는 카테고리입니다.");
+        }
+
+        Category entity = categoryRepository.findById(request.categoryId())
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 카테고리입니다."));
+
+        entity.setCategory(request.category());
+        entity.setColor(request.color());
+
+        try {
+            return categoryMapper.toCategoryDto(
+                    categoryRepository.save(entity)
+            );
+        } catch (DataIntegrityViolationException exception) {
+            throw new DuplicatedResourceException("이미 존재하는 카테고리입니다.");
+        }
+    }
+
     // TODO: 카테고리 삭제
+
+    /**
+     * 카테고리 명 중복 확인
+     *
+     * @param categoryName 중복 검사할 카테고리 이름
+     * @return true: 중복 값 있음, false: 중복 값 없음
+     */
+    private boolean checkCategoryNameIsInUse(String categoryName) {
+        return categoryRepository.existsByCategory(categoryName);
+    }
 }

--- a/src/main/java/com/upstage/devup/category/service/CategoryService.java
+++ b/src/main/java/com/upstage/devup/category/service/CategoryService.java
@@ -2,15 +2,21 @@ package com.upstage.devup.category.service;
 
 import com.upstage.devup.category.dto.CategoryAddRequest;
 import com.upstage.devup.category.dto.CategoryDto;
+import com.upstage.devup.category.dto.CategoryPageDto;
 import com.upstage.devup.category.dto.CategoryUpdateRequest;
 import com.upstage.devup.category.mapper.CategoryMapper;
 import com.upstage.devup.category.repository.CategoryRepository;
+import com.upstage.devup.global.domain.dto.PageDto;
 import com.upstage.devup.global.entity.Category;
 import com.upstage.devup.global.exception.DuplicatedResourceException;
 import com.upstage.devup.global.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +27,39 @@ public class CategoryService {
 
     private final CategoryRepository categoryRepository;
     private final CategoryMapper categoryMapper;
+
+    private static final int CATEGORIES_PER_PAGE = 10;
+
+    /**
+     * 카테고리 단건 조회
+     *
+     * @param categoryId 조회할 카테고리 ID
+     * @return 조회된 카테고리 정보
+     */
+    public CategoryDto findCategory(long categoryId) {
+
+        return categoryMapper.toCategoryDto(
+                categoryRepository.findById(categoryId)
+                        .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 카테고리입니다."))
+        );
+    }
+
+    /**
+     * 카테고리 목록 조회
+     *
+     * @param pageNumber 페이지 번호
+     * @return 조회된 카테고리 정보
+     */
+    public CategoryPageDto findCategories(int pageNumber) {
+
+        Sort sort = Sort.by(Sort.Direction.ASC, "id");
+        Pageable pageable = PageRequest.of(Math.max(0, pageNumber), CATEGORIES_PER_PAGE, sort);
+
+        Page<CategoryDto> page = categoryRepository.findAll(pageable)
+                .map(categoryMapper::toCategoryDto);
+
+        return new CategoryPageDto(page);
+    }
 
     /**
      * 카테고리 저장
@@ -80,7 +119,7 @@ public class CategoryService {
      *
      * @param categoryId 삭제할 카테고리 ID
      * @return 삭제된 카테고리 정보
-     * @throws EntityNotFoundException 존재하지 않는 카테고리를 삭제하려는 경우 발생
+     * @throws EntityNotFoundException         존재하지 않는 카테고리를 삭제하려는 경우 발생
      * @throws DataIntegrityViolationException 외래키로 사용 중인 카테고리를 삭제하려는 경우 발생
      */
     @Transactional

--- a/src/main/java/com/upstage/devup/category/service/CategoryService.java
+++ b/src/main/java/com/upstage/devup/category/service/CategoryService.java
@@ -74,7 +74,33 @@ public class CategoryService {
         }
     }
 
-    // TODO: 카테고리 삭제
+
+    /**
+     * 카테고리 삭제
+     *
+     * @param categoryId 삭제할 카테고리 ID
+     * @return 삭제된 카테고리 정보
+     * @throws EntityNotFoundException 존재하지 않는 카테고리를 삭제하려는 경우 발생
+     * @throws DataIntegrityViolationException 외래키로 사용 중인 카테고리를 삭제하려는 경우 발생
+     */
+    @Transactional
+    public CategoryDto deleteCategory(long categoryId) {
+
+        Category entity = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 카테고리입니다."));
+
+        try {
+            CategoryDto categoryDto = categoryMapper.toCategoryDto(entity);
+
+            categoryRepository.delete(entity);
+            categoryRepository.flush();
+
+            return categoryDto;
+        } catch (DataIntegrityViolationException e) {
+            log.error("삭제 실패: 해당 Category는 하나 이상의 Question에서 참조 중입니다.");
+            throw new DataIntegrityViolationException("삭제할 수 없습니다. 다른 데이터에서 이 항목을 사용 중입니다.");
+        }
+    }
 
     /**
      * 카테고리 명 중복 확인

--- a/src/main/java/com/upstage/devup/global/domain/dto/PageDto.java
+++ b/src/main/java/com/upstage/devup/global/domain/dto/PageDto.java
@@ -1,0 +1,33 @@
+package com.upstage.devup.global.domain.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+public abstract class PageDto<T> {
+
+    private final int number;
+    private final int size;
+    private final int totalPages;
+    private final long totalElements;
+
+    private final boolean hasPrevious;
+    private final boolean hasNext;
+
+    private final List<T> content;
+
+    public PageDto(@NotNull Page<T> page) {
+        this.number = page.getNumber();
+        this.size = page.getSize();
+        this.totalPages = page.getTotalPages();
+        this.totalElements = page.getTotalElements();
+
+        this.hasPrevious = page.hasPrevious();
+        this.hasNext = page.hasNext();
+
+        this.content = page.getContent();
+    }
+}

--- a/src/main/java/com/upstage/devup/global/entity/Category.java
+++ b/src/main/java/com/upstage/devup/global/entity/Category.java
@@ -17,7 +17,7 @@ public class Category {
 
     @Setter
     @Column(unique = true, nullable = false, length = 100)
-    private String category;
+    private String categoryName;
 
     @Setter
     @Column(nullable = false, length = 10)

--- a/src/main/java/com/upstage/devup/global/entity/Category.java
+++ b/src/main/java/com/upstage/devup/global/entity/Category.java
@@ -1,10 +1,7 @@
 package com.upstage.devup.global.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Table(name = "categories")
@@ -18,9 +15,11 @@ public class Category {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Setter
     @Column(unique = true, nullable = false, length = 100)
     private String category;
 
+    @Setter
     @Column(nullable = false, length = 10)
     private String color;
 

--- a/src/main/java/com/upstage/devup/global/exception/DuplicatedResourceException.java
+++ b/src/main/java/com/upstage/devup/global/exception/DuplicatedResourceException.java
@@ -1,0 +1,10 @@
+package com.upstage.devup.global.exception;
+
+/**
+ * 이미 존재하는 리소스를 중복으로 저장하려 할 때 발생하는 예외
+ */
+public class DuplicatedResourceException extends RuntimeException {
+    public DuplicatedResourceException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/upstage/devup/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/upstage/devup/global/handler/GlobalExceptionHandler.java
@@ -1,11 +1,9 @@
 package com.upstage.devup.global.handler;
 
-import com.upstage.devup.global.exception.InvalidLoginException;
-import com.upstage.devup.global.exception.UnauthenticatedException;
+import com.upstage.devup.global.exception.*;
 import com.upstage.devup.global.domain.dto.ErrorResponse;
-import com.upstage.devup.global.exception.EntityNotFoundException;
-import com.upstage.devup.global.exception.ValueAlreadyInUseException;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -62,5 +60,12 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(new ErrorResponse("VALIDATION_FAILED", message));
+    }
+
+    @ExceptionHandler(DuplicatedResourceException.class)
+    public ResponseEntity<ErrorResponse> handleDataIntegrityViolationException(DuplicatedResourceException e) {
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(new ErrorResponse(HttpStatus.CONFLICT.name(), e.getMessage()));
     }
 }

--- a/src/main/java/com/upstage/devup/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/upstage/devup/global/handler/GlobalExceptionHandler.java
@@ -68,4 +68,11 @@ public class GlobalExceptionHandler {
                 .status(HttpStatus.CONFLICT)
                 .body(new ErrorResponse(HttpStatus.CONFLICT.name(), e.getMessage()));
     }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ErrorResponse> handleDataIntegrityViolationException(DataIntegrityViolationException e) {
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(new ErrorResponse(HttpStatus.CONFLICT.name(), e.getMessage()));
+    }
 }

--- a/src/main/java/com/upstage/devup/question/service/QuestionService.java
+++ b/src/main/java/com/upstage/devup/question/service/QuestionService.java
@@ -86,7 +86,7 @@ public class QuestionService {
                 .id(question.getId())
                 .title(question.getTitle())
                 .questionText(question.getQuestionText())
-                .category(question.getCategory().getCategory())
+                .category(question.getCategory().getCategoryName())
                 .level(question.getLevel().getLevel())
                 .isBookmarked(isBookmarked)
                 .createdAt(question.getCreatedAt())

--- a/src/main/java/com/upstage/devup/user/answer/repository/UserAnswerStatRepository.java
+++ b/src/main/java/com/upstage/devup/user/answer/repository/UserAnswerStatRepository.java
@@ -22,7 +22,7 @@ public interface UserAnswerStatRepository extends JpaRepository<UserAnswerStat, 
     @Query(value = """
         SELECT
             c.id,
-            c.category,
+            c.category_name,
             c.color,
             COUNT(*)
         FROM user_answer_stats uas
@@ -31,7 +31,7 @@ public interface UserAnswerStatRepository extends JpaRepository<UserAnswerStat, 
         JOIN categories c
             ON q.category_id = c.id
         WHERE uas.user_id = :userId
-        GROUP BY c.id, c.category, c.color
+        GROUP BY c.id, c.category_name, c.color
     """, nativeQuery = true)
     List<CategoryCountDto> findCategoriesByUserId(Long userId);
 

--- a/src/main/java/com/upstage/devup/user/history/dto/UserSolvedHistoryDetailDto.java
+++ b/src/main/java/com/upstage/devup/user/history/dto/UserSolvedHistoryDetailDto.java
@@ -38,7 +38,7 @@ public class UserSolvedHistoryDetailDto {
                 .questionId(question.getId())
                 .questionTitle(question.getTitle())
                 .questionText(question.getQuestionText())
-                .category(question.getCategory().getCategory())
+                .category(question.getCategory().getCategoryName())
                 .level(question.getLevel().getLevel())
                 .userAnswerText(entity.getAnswerText())
                 .solvedAt(entity.getCreatedAt())

--- a/src/main/java/com/upstage/devup/user/history/dto/UserSolvedQuestionDto.java
+++ b/src/main/java/com/upstage/devup/user/history/dto/UserSolvedQuestionDto.java
@@ -31,7 +31,7 @@ public class UserSolvedQuestionDto {
                 .id(entity.getId())
                 .questionId(entity.getQuestion().getId())
                 .questionTitle(entity.getQuestion().getTitle())
-                .category(entity.getQuestion().getCategory().getCategory())
+                .category(entity.getQuestion().getCategory().getCategoryName())
                 .level(entity.getQuestion().getLevel().getLevel())
                 .solvedAt(entity.getCreatedAt())
                 .isCorrect(entity.getIsCorrect())

--- a/src/main/java/com/upstage/devup/user/wrong/service/UserWrongAnswerQueryService.java
+++ b/src/main/java/com/upstage/devup/user/wrong/service/UserWrongAnswerQueryService.java
@@ -53,7 +53,7 @@ public class UserWrongAnswerQueryService {
                 .userId(entity.getUser().getId())
                 .questionId(question.getId())
                 .title(question.getTitle())
-                .category(question.getCategory().getCategory())
+                .category(question.getCategory().getCategoryName())
                 .level(question.getLevel().getLevel())
                 .createdAt(entity.getCreatedAt())
                 .build();

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,6 +1,6 @@
 -- 카테고리 (categories)
 INSERT INTO categories
-    (id, category, color)
+    (id, category_name, color)
 VALUES
     (1, 'CI/CD', '#40C9A2'),
     (2, 'Database', '#FFD93D'),

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -18,14 +18,14 @@ CREATE TABLE bookmarks
 
 CREATE TABLE categories
 (
-    id       BIGINT       NOT NULL AUTO_INCREMENT,
-    category VARCHAR(100) NOT NULL,
-    color    VARCHAR(10)  NOT NULL COMMENT '카테고리 바에 표시할 색상',
+    id              BIGINT       NOT NULL AUTO_INCREMENT,
+    category_name   VARCHAR(100) NOT NULL,
+    color           VARCHAR(10)  NOT NULL COMMENT '카테고리 바에 표시할 색상',
     PRIMARY KEY (id)
 ); -- '기술 면접 주제'
 
 ALTER TABLE categories
-    ADD CONSTRAINT UQ_category UNIQUE (category);
+    ADD CONSTRAINT UQ_category UNIQUE (category_name);
 
 CREATE TABLE levels
 (

--- a/src/test/java/com/upstage/devup/category/controller/CategoryControllerTest.java
+++ b/src/test/java/com/upstage/devup/category/controller/CategoryControllerTest.java
@@ -1,0 +1,126 @@
+package com.upstage.devup.category.controller;
+
+import com.upstage.devup.Util;
+import com.upstage.devup.auth.config.SecurityConfig;
+import com.upstage.devup.auth.config.jwt.JwtTokenProvider;
+import com.upstage.devup.category.dto.CategoryDto;
+import com.upstage.devup.category.service.CategoryService;
+import com.upstage.devup.global.exception.EntityNotFoundException;
+import com.upstage.devup.global.handler.GlobalExceptionHandler;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = {CategoryController.class, GlobalExceptionHandler.class})
+@Import(SecurityConfig.class)
+class CategoryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private CategoryService categoryService;
+
+    private static final String URL_TEMPLATE = "/api/admin/category/";
+    private static final long userId = 1L;
+    private static final String ROLE_ADMIN = "ROLE_ADMIN";
+
+    @Nested
+    @DisplayName("카테고리 삭제 테스트")
+    public class DeletionTest {
+
+        @Nested
+        @DisplayName("성공 케이스")
+        public class SuccessCases {
+
+            @Test
+            @DisplayName("외래키로 사용되지 않는 카테고리를 삭제하는 경우")
+            public void shouldReturn200_whenCategoryIsNotUsedByForeignKey() throws Exception {
+                // given
+                long categoryId = 1L;
+                String categoryName = "삭제할 카테고리";
+                String color = "#123456";
+
+                when(categoryService.deleteCategory(eq(categoryId)))
+                        .thenReturn(new CategoryDto(categoryId, categoryName, color));
+
+                // when & then
+                mockMvc.perform(delete(URL_TEMPLATE + categoryId)
+                                .with(Util.getAuthentication(userId, ROLE_ADMIN)))
+                        .andExpect(status().isOk())
+                        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                        .andExpect(jsonPath("$.id").value(categoryId))
+                        .andExpect(jsonPath("$.categoryName").value(categoryName))
+                        .andExpect(jsonPath("$.color").value(color));
+
+                verify(categoryService).deleteCategory(eq(categoryId));
+            }
+        }
+
+        @Nested
+        @DisplayName("실패 케이스")
+        public class FailureCases {
+
+            @Test
+            @DisplayName("외래키로 사용되는 카테고리를 삭제하는 경우")
+            public void shouldReturn409_whenCategoryIsUsedByForeignKey() throws Exception {
+                // given
+                long categoryId = 2L;
+                String errorMessage = "삭제할 수 없습니다. 다른 데이터에서 이 항목을 사용 중입니다.";
+
+                when(categoryService.deleteCategory(eq(categoryId)))
+                        .thenThrow(
+                                new DataIntegrityViolationException(errorMessage)
+                        );
+
+                // when & then
+                mockMvc.perform(delete(URL_TEMPLATE + categoryId)
+                                .with(Util.getAuthentication(userId, ROLE_ADMIN)))
+                        .andExpect(status().isConflict())
+                        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                        .andExpect(jsonPath("$.code").value(HttpStatus.CONFLICT.name()))
+                        .andExpect(jsonPath("$.message").value(errorMessage));
+
+                verify(categoryService).deleteCategory(eq(categoryId));
+            }
+
+            @Test
+            @DisplayName("등록되지 않은 카테고리를 삭제하는 경우")
+            public void shouldReturn404_whenCategoryDoesNotExist() throws Exception {
+                // given
+                long categoryId = Long.MAX_VALUE;
+                String errorMessage = "존재하지 않는 카테고리입니다.";
+
+                when(categoryService.deleteCategory(eq(categoryId)))
+                        .thenThrow(
+                                new EntityNotFoundException(errorMessage)
+                        );
+
+                // when & then
+                mockMvc.perform(delete(URL_TEMPLATE + categoryId)
+                                .with(Util.getAuthentication(userId, ROLE_ADMIN)))
+                        .andExpect(status().isNotFound())
+                        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                        .andExpect(jsonPath("$.code").value(HttpStatus.NOT_FOUND.name()))
+                        .andExpect(jsonPath("$.message").value(errorMessage));
+
+                verify(categoryService).deleteCategory(eq(categoryId));
+            }
+        }
+    }
+}

--- a/src/test/java/com/upstage/devup/category/service/CategoryServiceTest.java
+++ b/src/test/java/com/upstage/devup/category/service/CategoryServiceTest.java
@@ -1,0 +1,98 @@
+package com.upstage.devup.category.service;
+
+import com.upstage.devup.category.dto.CategoryAddRequest;
+import com.upstage.devup.category.dto.CategoryDto;
+import com.upstage.devup.global.exception.DuplicatedResourceException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@Transactional
+class CategoryServiceTest {
+
+    @Autowired
+    private CategoryService categoryService;
+
+    @Nested
+    @DisplayName("카테고리 등록 테스트")
+    public class CategoryRegistration {
+
+        @Nested
+        @DisplayName("성공 케이스")
+        public class SuccessCases {
+
+            @Test
+            @DisplayName("등록되지 않은 categoryName을 저장하는 경우")
+            public void shouldSaveCategory_whenCategoryNameDoesNotExistsInDB() {
+                // given
+                String categoryName = "new category";
+                String color = "#b0b0b0";
+                CategoryAddRequest request = new CategoryAddRequest(categoryName, color);
+
+                // when
+                CategoryDto result = categoryService.addCategory(request);
+
+                // then
+                assertThat(result).isNotNull();
+                assertThat(result.id()).isGreaterThan(0L);
+                assertThat(result.categoryName()).isEqualTo(categoryName);
+                assertThat(result.color()).isEqualTo(color);
+            }
+
+            @Test
+            @DisplayName("color 값이 중복되어도 categoryName이 다르면 저장할 수 있음")
+            public void shouldSaveCategory_whenColorIsDuplicatedButNameIsDifferent() {
+                // given
+                String categoryName = "new category";
+                String color = "#b0b0b0";
+                categoryService.addCategory(new CategoryAddRequest("old category", color));
+
+                CategoryAddRequest request = new CategoryAddRequest(categoryName, color);
+
+                // when
+                CategoryDto result = categoryService.addCategory(request);
+
+                // then
+                assertThat(result).isNotNull();
+                assertThat(result.id()).isGreaterThan(0L);
+                assertThat(result.categoryName()).isEqualTo(categoryName);
+                assertThat(result.color()).isEqualTo(color);
+            }
+        }
+
+        @Nested
+        @DisplayName("실패 케이스")
+        public class FailureCases {
+
+            @Test
+            @DisplayName("같은 categoryName을 저장하는 경우 - DuplicatedResourceException 발생")
+            public void shouldThrowDuplicatedResourceException_whenCategoryNameExistsInDB() {
+                // given
+                String categoryName = "new category";
+                String color = "#b0b0b0";
+                categoryService.addCategory(new CategoryAddRequest(categoryName, color));
+
+                CategoryAddRequest request = new CategoryAddRequest(categoryName, color);
+
+                // when
+                DuplicatedResourceException exception = assertThrows(
+                        DuplicatedResourceException.class,
+                        () -> categoryService.addCategory(request)
+                );
+
+                // then
+                assertThat(exception.getMessage()).isEqualTo("이미 존재하는 카테고리입니다.");
+            }
+        }
+    }
+
+
+}

--- a/src/test/java/com/upstage/devup/category/service/CategoryServiceTest.java
+++ b/src/test/java/com/upstage/devup/category/service/CategoryServiceTest.java
@@ -2,13 +2,17 @@ package com.upstage.devup.category.service;
 
 import com.upstage.devup.category.dto.CategoryAddRequest;
 import com.upstage.devup.category.dto.CategoryDto;
+import com.upstage.devup.category.dto.CategoryUpdateRequest;
 import com.upstage.devup.global.exception.DuplicatedResourceException;
+import com.upstage.devup.global.exception.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.HttpStatus;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -20,6 +24,21 @@ class CategoryServiceTest {
 
     @Autowired
     private CategoryService categoryService;
+
+    long savedCategoryId;
+    String savedCategoryName;
+    String savedColor;
+
+    @BeforeEach
+    public void beforeEach() {
+        CategoryDto categoryDto = categoryService.addCategory(
+                new CategoryAddRequest("old", "#000000")
+        );
+
+        this.savedCategoryId = categoryDto.id();
+        this.savedCategoryName = categoryDto.categoryName();
+        this.savedColor = categoryDto.color();
+    }
 
     @Nested
     @DisplayName("카테고리 등록 테스트")
@@ -52,10 +71,7 @@ class CategoryServiceTest {
             public void shouldSaveCategory_whenColorIsDuplicatedButNameIsDifferent() {
                 // given
                 String categoryName = "new category";
-                String color = "#b0b0b0";
-                categoryService.addCategory(new CategoryAddRequest("old category", color));
-
-                CategoryAddRequest request = new CategoryAddRequest(categoryName, color);
+                CategoryAddRequest request = new CategoryAddRequest(categoryName, savedColor);
 
                 // when
                 CategoryDto result = categoryService.addCategory(request);
@@ -64,7 +80,7 @@ class CategoryServiceTest {
                 assertThat(result).isNotNull();
                 assertThat(result.id()).isGreaterThan(0L);
                 assertThat(result.categoryName()).isEqualTo(categoryName);
-                assertThat(result.color()).isEqualTo(color);
+                assertThat(result.color()).isEqualTo(savedColor);
             }
         }
 
@@ -76,11 +92,8 @@ class CategoryServiceTest {
             @DisplayName("같은 categoryName을 저장하는 경우 - DuplicatedResourceException 발생")
             public void shouldThrowDuplicatedResourceException_whenCategoryNameExistsInDB() {
                 // given
-                String categoryName = "new category";
                 String color = "#b0b0b0";
-                categoryService.addCategory(new CategoryAddRequest(categoryName, color));
-
-                CategoryAddRequest request = new CategoryAddRequest(categoryName, color);
+                CategoryAddRequest request = new CategoryAddRequest(savedCategoryName, color);
 
                 // when
                 DuplicatedResourceException exception = assertThrows(
@@ -94,5 +107,95 @@ class CategoryServiceTest {
         }
     }
 
+    @Nested
+    @DisplayName("카테고리 수정 테스트")
+    public class CategoryUpdateTest {
 
+        @Nested
+        @DisplayName("성공 케이스")
+        public class SuccessCases {
+
+            @Test
+            @DisplayName("등록되지 않은 categoryName 값을 사용한 경우")
+            public void shouldUpdateCategory() {
+                // given
+                String categoryName = "new category";
+                String color = "#111111";
+                CategoryUpdateRequest request = new CategoryUpdateRequest(savedCategoryId, categoryName, color);
+
+                // when
+                CategoryDto result = categoryService.updateCategory(request);
+
+                // then
+                assertThat(result).isNotNull();
+                assertThat(result.id()).isEqualTo(savedCategoryId);
+                assertThat(result.categoryName()).isEqualTo(categoryName);
+                assertThat(result.color()).isEqualTo(color);
+            }
+
+            @Test
+            @DisplayName("color 값이 중복되어도 categoryName이 다르면 수정할 수 있음")
+            public void shouldUpdateCategory_whenColorIsDifferentButCategoryNameExistsInDB() {
+                // given
+                String categoryName = "new category";
+                CategoryUpdateRequest request = new CategoryUpdateRequest(
+                        savedCategoryId, categoryName, savedColor
+                );
+
+                // when
+                CategoryDto result = categoryService.updateCategory(request);
+
+                // then
+                assertThat(result).isNotNull();
+                assertThat(result.id()).isEqualTo(savedCategoryId);
+                assertThat(result.categoryName()).isEqualTo(categoryName);
+                assertThat(result.color()).isEqualTo(savedColor);
+            }
+        }
+
+        @Nested
+        @DisplayName("실패 케이스")
+        public class FailureCases {
+
+            @Test
+            @DisplayName("중복된 categoryName 값을 사용하는 경우 - DuplicatedResourceException 발생")
+            public void shouldThrowDuplicatedResourceException_whenCategoryNameExistsInDB() {
+                // given
+                String color = "#111111";
+                CategoryUpdateRequest request = new CategoryUpdateRequest(savedCategoryId, savedCategoryName, color);
+
+                // when
+                DuplicatedResourceException exception = assertThrows(
+                        DuplicatedResourceException.class,
+                        () -> categoryService.updateCategory(request)
+                );
+
+                // then
+                assertThat(exception.getMessage()).isEqualTo("이미 존재하는 카테고리입니다.");
+            }
+
+            @ParameterizedTest
+            @CsvSource(value = {
+                    "0",
+                    "-1",
+                    "9223372036854775807"
+            })
+            @DisplayName("유효하지 않은 categoryId를 사용하는 경우 - EntityNotFoundException 발생")
+            public void shouldThrowDEntityNotFoundException_whenCategoryEntityDoesNotExistsInDB(long categoryId) {
+                // given
+                String categoryName = "new category";
+                String color = "#111111";
+                CategoryUpdateRequest request = new CategoryUpdateRequest(categoryId, categoryName, color);
+
+                // when
+                EntityNotFoundException exception = assertThrows(
+                        EntityNotFoundException.class,
+                        () -> categoryService.updateCategory(request)
+                );
+
+                // then
+                assertThat(exception.getMessage()).isEqualTo("존재하지 않는 카테고리입니다.");
+            }
+        }
+    }
 }

--- a/src/test/java/com/upstage/devup/question/service/QuestionServiceTest.java
+++ b/src/test/java/com/upstage/devup/question/service/QuestionServiceTest.java
@@ -156,7 +156,7 @@ class QuestionServiceTest {
                 assertThat(result.getId()).isEqualTo(question.getId());
                 assertThat(result.getTitle()).isEqualTo(question.getTitle());
                 assertThat(result.getQuestionText()).isEqualTo(question.getQuestionText());
-                assertThat(result.getCategory()).isEqualTo(question.getCategory().getCategory());
+                assertThat(result.getCategory()).isEqualTo(question.getCategory().getCategoryName());
                 assertThat(result.getLevel()).isEqualTo(question.getLevel().getLevel());
                 assertThat(result.isBookmarked()).isFalse();
                 assertThat(result.getCreatedAt()).isEqualTo(question.getCreatedAt());
@@ -176,7 +176,7 @@ class QuestionServiceTest {
                 assertThat(result.getId()).isEqualTo(question.getId());
                 assertThat(result.getTitle()).isEqualTo(question.getTitle());
                 assertThat(result.getQuestionText()).isEqualTo(question.getQuestionText());
-                assertThat(result.getCategory()).isEqualTo(question.getCategory().getCategory());
+                assertThat(result.getCategory()).isEqualTo(question.getCategory().getCategoryName());
                 assertThat(result.getLevel()).isEqualTo(question.getLevel().getLevel());
                 assertThat(result.isBookmarked()).isFalse();
                 assertThat(result.getCreatedAt()).isEqualTo(question.getCreatedAt());
@@ -202,7 +202,7 @@ class QuestionServiceTest {
                 assertThat(result.getId()).isEqualTo(question.getId());
                 assertThat(result.getTitle()).isEqualTo(question.getTitle());
                 assertThat(result.getQuestionText()).isEqualTo(question.getQuestionText());
-                assertThat(result.getCategory()).isEqualTo(question.getCategory().getCategory());
+                assertThat(result.getCategory()).isEqualTo(question.getCategory().getCategoryName());
                 assertThat(result.getLevel()).isEqualTo(question.getLevel().getLevel());
                 assertThat(result.isBookmarked()).isTrue();
                 assertThat(result.getCreatedAt()).isEqualTo(question.getCreatedAt());


### PR DESCRIPTION
## 작업 내용

### 저장 기능
- 카테고리 저장 전 카테고리 이름 중복 검사
- 중복된 값이 있는 경우 `DuplicatedResourceException` 예외 발생

### 수정 기능
- 카테고리 수정 전 변경하려는 카테고리 이름이 사용중인지 확인
- 카테고리 이름이 사용중이라면 `DuplicatedResourceException` 예외 발생
- 조회된 카테고리가 없는 경우 `EntityNotFoundException` 예외 발생

### 삭제 기능
- 조회된 카테고리가 없는 경우 `EntityNotFoundException` 예외 발생
- 외래키로 사용중인 카테고리를 삭제하려는 경우 `DataIntegrityViolationException` 예외 발생

### 조회 기능
- 단건 조회, 목록 조회 기능 구현
- 조회된 카테고리가 없는 경우 `EntityNotFoundException` 예외 발생
- 목록 조회 시
  - `pageNumber`가 음수인 경우 → 첫 번째 페이지 정보를 반환
  - `pageNumber`가 마지막 페이지 번호보다 큰 경우 → 빈 페이지 정보를 반환

### API 구현
- 저장, 수정, 삭제용 API 구현
- 조회용 API는 추후 구현 예정


## API 명세
|API|메서드|설명|
|---|---|---|
|`/api/admin/category`|`POST`|카테고리 등록|
|`/api/admin/category`|`PATCH`|카테고리 수정|
|`/api/admin/category/{categoryId}`|`DELETE`|카테고리 삭제|

## 참고사항

### 응답용 DTO
|DTO 명|설명|
|---|---|
|`CategoryDto`|- 카테고리 1개의 정보|
|`CategoryPageDto`|- 페이지 정보와 복수의 카테고리 정보|
|`PageDto`|- Page 객체를 직접 반환하지 않기 위한 공통 응답 DTO<br>- 확장성과 재사용성을 고려해 Generic 타입으로 설계<br>- 실제 응답용 DTO는 `PageDto`를 상속받아 사용|

### 삭제 기능 테스트 이슈
- 외래키로 사용중인 카테고리를 삭제하는 경우는 테스트 하지 못함
- 로그에는 `save the transient instance before flushing`이라고 나타남
- 테스트 코드의 `@transactional`을 제거하면 성공했지만, 다른 테스트 코드들이 실패함
- 관련 내용을 공부하고 추후 테스트를 진행할 예정