### PR TITLE
feat: Level 엔티티 수정 및 난이도 CRUD 기능 구현

### DIFF
--- a/docs/erd/v1.0.4.erd
+++ b/docs/erd/v1.0.4.erd
@@ -158,15 +158,15 @@
           "eQVTYYo6DkFvrgl8uc08f"
         ],
         "ui": {
-          "x": 1112.896,
-          "y": 1091.7079,
+          "x": 1111.896,
+          "y": 1117.7079,
           "zIndex": 67,
           "widthName": 62,
           "widthComment": 71,
           "color": ""
         },
         "meta": {
-          "updateAt": 1749270063444,
+          "updateAt": 1749540427953,
           "createAt": 1745497478333
         }
       },
@@ -176,22 +176,26 @@
         "comment": "난이도",
         "columnIds": [
           "7-m0nv5D2FbXOnd4f4Bgm",
-          "PZNJcHrv12XoDKy1E94EA"
+          "PZNJcHrv12XoDKy1E94EA",
+          "612XJ3xODjb8kKWTZ20fp",
+          "rEBt4-GREskM3VwLQIaLd"
         ],
         "seqColumnIds": [
           "7-m0nv5D2FbXOnd4f4Bgm",
-          "PZNJcHrv12XoDKy1E94EA"
+          "PZNJcHrv12XoDKy1E94EA",
+          "612XJ3xODjb8kKWTZ20fp",
+          "rEBt4-GREskM3VwLQIaLd"
         ],
         "ui": {
-          "x": 1446.3098,
-          "y": 943.1503,
+          "x": 1436.3098,
+          "y": 903.1503,
           "zIndex": 102,
           "widthName": 60,
           "widthComment": 60,
           "color": ""
         },
         "meta": {
-          "updateAt": 1749270066226,
+          "updateAt": 1749540425285,
           "createAt": 1745497833117
         }
       },
@@ -339,15 +343,15 @@
           "FJv128iZQYa6bUl9XgjCt"
         ],
         "ui": {
-          "x": 783.8909,
-          "y": 930.1892,
+          "x": 785.8909,
+          "y": 922.1892,
           "zIndex": 206,
           "widthName": 85,
           "widthComment": 71,
           "color": ""
         },
         "meta": {
-          "updateAt": 1749270063444,
+          "updateAt": 1749540432120,
           "createAt": 1745498558417
         }
       },
@@ -1861,6 +1865,46 @@
           "updateAt": 1749270158889,
           "createAt": 1749270153180
         }
+      },
+      "612XJ3xODjb8kKWTZ20fp": {
+        "id": "612XJ3xODjb8kKWTZ20fp",
+        "tableId": "_CIKzC1_ech2NHfwtp4ZP",
+        "name": "created_at",
+        "comment": "등록일",
+        "dataType": "TIMESTAMP",
+        "default": "CURRENT_TIMESTAMP",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 63,
+          "widthComment": 60,
+          "widthDataType": 71,
+          "widthDefault": 133
+        },
+        "meta": {
+          "updateAt": 1749540421757,
+          "createAt": 1749540385646
+        }
+      },
+      "rEBt4-GREskM3VwLQIaLd": {
+        "id": "rEBt4-GREskM3VwLQIaLd",
+        "tableId": "_CIKzC1_ech2NHfwtp4ZP",
+        "name": "modified_at",
+        "comment": "수정일",
+        "dataType": "TIMESTAMP",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 69,
+          "widthComment": 60,
+          "widthDataType": 71,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1749540418122,
+          "createAt": 1749540408685
+        }
       }
     },
     "relationshipEntities": {
@@ -1874,8 +1918,8 @@
           "columnIds": [
             "bYBD1G5Rtzfd5bmHp1PSN"
           ],
-          "x": 1369.396,
-          "y": 1091.7079,
+          "x": 1368.396,
+          "y": 1117.7079,
           "direction": 4
         },
         "end": {
@@ -1902,8 +1946,8 @@
           "columnIds": [
             "7-m0nv5D2FbXOnd4f4Bgm"
           ],
-          "x": 1666.8098,
-          "y": 943.1503,
+          "x": 1697.8098,
+          "y": 903.1503,
           "direction": 4
         },
         "end": {
@@ -2135,8 +2179,8 @@
           "columnIds": [
             "mABxR9m0G66KTu3BI1ZAU"
           ],
-          "x": 1261.8908999999999,
-          "y": 1006.1892,
+          "x": 1263.8908999999999,
+          "y": 998.1892,
           "direction": 2
         },
         "meta": {

--- a/docs/erd/v1.0.4.erd
+++ b/docs/erd/v1.0.4.erd
@@ -10,7 +10,7 @@
     "show": 511,
     "database": 1,
     "databaseName": "db_devup",
-    "canvasType": "@dineug/erd-editor/builtin-schema-sql",
+    "canvasType": "ERD",
     "language": 1,
     "tableNameCase": 4,
     "columnNameCase": 2,
@@ -729,20 +729,20 @@
       "PZNJcHrv12XoDKy1E94EA": {
         "id": "PZNJcHrv12XoDKy1E94EA",
         "tableId": "_CIKzC1_ech2NHfwtp4ZP",
-        "name": "level",
+        "name": "level_name",
         "comment": "",
         "dataType": "VARCHAR(50)",
         "default": "",
         "options": 12,
         "ui": {
           "keys": 0,
-          "widthName": 60,
+          "widthName": 66,
           "widthComment": 60,
           "widthDataType": 83,
           "widthDefault": 60
         },
         "meta": {
-          "updateAt": 1745508112116,
+          "updateAt": 1749540824082,
           "createAt": 1745497853138
         }
       },

--- a/src/main/java/com/upstage/devup/admin/level/dto/LevelAddRequest.java
+++ b/src/main/java/com/upstage/devup/admin/level/dto/LevelAddRequest.java
@@ -1,0 +1,9 @@
+package com.upstage.devup.admin.level.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LevelAddRequest(
+        @NotBlank(message = "난이도를 입력해 주세요.")
+        String levelName
+) {
+}

--- a/src/main/java/com/upstage/devup/admin/level/dto/LevelDto.java
+++ b/src/main/java/com/upstage/devup/admin/level/dto/LevelDto.java
@@ -1,0 +1,17 @@
+package com.upstage.devup.admin.level.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+
+public record LevelDto(
+        long levelId,
+        String levelName,
+
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime createdAt,
+
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime modifiedAt
+) {
+}

--- a/src/main/java/com/upstage/devup/admin/level/dto/LevelPageDto.java
+++ b/src/main/java/com/upstage/devup/admin/level/dto/LevelPageDto.java
@@ -1,0 +1,11 @@
+package com.upstage.devup.admin.level.dto;
+
+import com.upstage.devup.global.domain.dto.PageDto;
+import org.springframework.data.domain.Page;
+
+public class LevelPageDto extends PageDto<LevelDto> {
+
+    public LevelPageDto(Page<LevelDto> page) {
+        super(page);
+    }
+}

--- a/src/main/java/com/upstage/devup/admin/level/dto/LevelUpdateRequest.java
+++ b/src/main/java/com/upstage/devup/admin/level/dto/LevelUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.upstage.devup.admin.level.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record LevelUpdateRequest(
+        @NotNull(message = "난이도를 선택해 주세요.")
+        Long levelId,
+
+        @NotBlank(message = "난이도를 입력해 주세요.")
+        String levelName
+) {
+}

--- a/src/main/java/com/upstage/devup/admin/level/mapper/LevelMapper.java
+++ b/src/main/java/com/upstage/devup/admin/level/mapper/LevelMapper.java
@@ -1,0 +1,21 @@
+package com.upstage.devup.admin.level.mapper;
+
+import com.upstage.devup.admin.level.dto.LevelDto;
+import com.upstage.devup.global.entity.Level;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LevelMapper {
+
+    private LevelMapper() {
+    }
+
+    public LevelDto toLevelDto(Level entity) {
+        return new LevelDto(
+                entity.getId(),
+                entity.getLevelName(),
+                entity.getCreatedAt(),
+                entity.getModifiedAt()
+        );
+    }
+}

--- a/src/main/java/com/upstage/devup/admin/level/repository/LevelRepository.java
+++ b/src/main/java/com/upstage/devup/admin/level/repository/LevelRepository.java
@@ -1,0 +1,10 @@
+package com.upstage.devup.admin.level.repository;
+
+import com.upstage.devup.global.entity.Level;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LevelRepository extends JpaRepository<Level, Long> {
+    boolean existsByLevelName(String levelName);
+}

--- a/src/main/java/com/upstage/devup/admin/level/service/LevelService.java
+++ b/src/main/java/com/upstage/devup/admin/level/service/LevelService.java
@@ -1,0 +1,62 @@
+package com.upstage.devup.admin.level.service;
+
+import com.upstage.devup.admin.level.dto.LevelAddRequest;
+import com.upstage.devup.admin.level.dto.LevelDto;
+import com.upstage.devup.admin.level.mapper.LevelMapper;
+import com.upstage.devup.admin.level.repository.LevelRepository;
+import com.upstage.devup.global.entity.Level;
+import com.upstage.devup.global.exception.DuplicatedResourceException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LevelService {
+
+    private final LevelRepository levelRepository;
+
+    private final LevelMapper levelMapper;
+
+    // TODO: 난이도 단건 조회
+    // TODO: 난이도 목록 조회
+
+
+    /**
+     * 신규 난이도 등록
+     *
+     * @param request 새로 등록할 난이도 정보
+     * @return 등록된 난이도 정보
+     * @throws DuplicatedResourceException 중복된 난이도를 등록하려는 경우 발생
+     */
+    public LevelDto addLevel(LevelAddRequest request) {
+
+        if (checkLevelNameIsInUse(request.levelName())) {
+            throw new DuplicatedResourceException("이미 사용중인 난이도입니다.");
+        }
+
+        Level entity = levelRepository.save(Level.builder()
+                .levelName(request.levelName())
+                .createdAt(LocalDateTime.now())
+                .build());
+
+        return levelMapper.toLevelDto(entity);
+    }
+
+
+    // TODO: 난이도 수정
+    // TODO: 난이도 삭제
+
+    /**
+     * 난이도 이름 중복 검사
+     *
+     * @param levelName 중복 검사할 난이도 이름
+     * @return true: 중복됨, false: 중복되지 않음
+     */
+    private boolean checkLevelNameIsInUse(String levelName) {
+        return levelRepository.existsByLevelName(levelName);
+    }
+}

--- a/src/main/java/com/upstage/devup/admin/level/service/LevelService.java
+++ b/src/main/java/com/upstage/devup/admin/level/service/LevelService.java
@@ -2,13 +2,16 @@ package com.upstage.devup.admin.level.service;
 
 import com.upstage.devup.admin.level.dto.LevelAddRequest;
 import com.upstage.devup.admin.level.dto.LevelDto;
+import com.upstage.devup.admin.level.dto.LevelUpdateRequest;
 import com.upstage.devup.admin.level.mapper.LevelMapper;
 import com.upstage.devup.admin.level.repository.LevelRepository;
 import com.upstage.devup.global.entity.Level;
 import com.upstage.devup.global.exception.DuplicatedResourceException;
+import com.upstage.devup.global.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
@@ -21,6 +24,9 @@ public class LevelService {
 
     private final LevelMapper levelMapper;
 
+    private static final String ERR_MSG_DUPLICATED_RESOURCE = "이미 사용중인 난이도입니다.";
+    private static final String ERR_MSG_ENTITY_NOT_FOUND = "존재하지 않는 난이도입니다.";
+
     // TODO: 난이도 단건 조회
     // TODO: 난이도 목록 조회
 
@@ -32,10 +38,11 @@ public class LevelService {
      * @return 등록된 난이도 정보
      * @throws DuplicatedResourceException 중복된 난이도를 등록하려는 경우 발생
      */
+    @Transactional
     public LevelDto addLevel(LevelAddRequest request) {
 
-        if (checkLevelNameIsInUse(request.levelName())) {
-            throw new DuplicatedResourceException("이미 사용중인 난이도입니다.");
+        if (isLevelNameDuplicated(request.levelName())) {
+            throw new DuplicatedResourceException(ERR_MSG_DUPLICATED_RESOURCE);
         }
 
         Level entity = levelRepository.save(Level.builder()
@@ -46,8 +53,29 @@ public class LevelService {
         return levelMapper.toLevelDto(entity);
     }
 
+    /**
+     * 난이도 수정
+     *
+     * @param request 수정할 난이도 정보
+     * @return 수정된 난이도 정보
+     * @throws DuplicatedResourceException 이미 사용중인 난이도 이름을 사용한 경우 발생
+     * @throws EntityNotFoundException 존재하지 않는 난이도 ID를 사용한 경우 발생
+     */
+    @Transactional
+    public LevelDto updateLevel(LevelUpdateRequest request) {
 
-    // TODO: 난이도 수정
+        if (isLevelNameDuplicated(request.levelName())) {
+            throw new DuplicatedResourceException(ERR_MSG_DUPLICATED_RESOURCE);
+        }
+
+        Level entity = levelRepository.findById(request.levelId())
+                .orElseThrow(() -> new EntityNotFoundException(ERR_MSG_ENTITY_NOT_FOUND));
+
+        entity.setLevelName(request.levelName());
+
+        return levelMapper.toLevelDto(entity);
+    }
+
     // TODO: 난이도 삭제
 
     /**
@@ -56,7 +84,7 @@ public class LevelService {
      * @param levelName 중복 검사할 난이도 이름
      * @return true: 중복됨, false: 중복되지 않음
      */
-    private boolean checkLevelNameIsInUse(String levelName) {
+    private boolean isLevelNameDuplicated(String levelName) {
         return levelRepository.existsByLevelName(levelName);
     }
 }

--- a/src/main/java/com/upstage/devup/admin/level/service/LevelService.java
+++ b/src/main/java/com/upstage/devup/admin/level/service/LevelService.java
@@ -5,7 +5,6 @@ import com.upstage.devup.admin.level.dto.LevelDto;
 import com.upstage.devup.admin.level.dto.LevelUpdateRequest;
 import com.upstage.devup.admin.level.mapper.LevelMapper;
 import com.upstage.devup.admin.level.repository.LevelRepository;
-import com.upstage.devup.category.dto.CategoryDto;
 import com.upstage.devup.global.entity.Level;
 import com.upstage.devup.global.exception.DuplicatedResourceException;
 import com.upstage.devup.global.exception.EntityNotFoundException;
@@ -29,7 +28,21 @@ public class LevelService {
     private static final String ERR_MSG_DUPLICATED_RESOURCE = "이미 사용중인 난이도입니다.";
     private static final String ERR_MSG_ENTITY_NOT_FOUND = "존재하지 않는 난이도입니다.";
 
-    // TODO: 난이도 단건 조회
+    /**
+     * 난이도 단건 조회
+     *
+     * @param levelId 조회할 난이도 ID
+     * @return 조회된 난이도 정보
+     * @throws EntityNotFoundException 존재하지 않는 난이도 ID를 사용하는 경우 발생
+     */
+    public LevelDto getLevel(long levelId) {
+
+        return levelMapper.toLevelDto(
+                levelRepository.findById(levelId)
+                        .orElseThrow(() -> new EntityNotFoundException(ERR_MSG_ENTITY_NOT_FOUND))
+        );
+    }
+
     // TODO: 난이도 목록 조회
 
 
@@ -83,7 +96,7 @@ public class LevelService {
      *
      * @param levelId 삭제할 난이도 ID
      * @return 삭제된 난이도 정보
-     * @throws EntityNotFoundException 존재하지 않는 난이도 ID를 사용한 경우 발생
+     * @throws EntityNotFoundException         존재하지 않는 난이도 ID를 사용한 경우 발생
      * @throws DataIntegrityViolationException 삭제하려는 난이도가 외래키로 사용중인 경우 발생
      */
     @Transactional

--- a/src/main/java/com/upstage/devup/admin/level/service/LevelService.java
+++ b/src/main/java/com/upstage/devup/admin/level/service/LevelService.java
@@ -2,6 +2,7 @@ package com.upstage.devup.admin.level.service;
 
 import com.upstage.devup.admin.level.dto.LevelAddRequest;
 import com.upstage.devup.admin.level.dto.LevelDto;
+import com.upstage.devup.admin.level.dto.LevelPageDto;
 import com.upstage.devup.admin.level.dto.LevelUpdateRequest;
 import com.upstage.devup.admin.level.mapper.LevelMapper;
 import com.upstage.devup.admin.level.repository.LevelRepository;
@@ -11,6 +12,10 @@ import com.upstage.devup.global.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +32,7 @@ public class LevelService {
 
     private static final String ERR_MSG_DUPLICATED_RESOURCE = "이미 사용중인 난이도입니다.";
     private static final String ERR_MSG_ENTITY_NOT_FOUND = "존재하지 않는 난이도입니다.";
+    private static final int LEVELS_PER_PAGE = 10;
 
     /**
      * 난이도 단건 조회
@@ -43,7 +49,23 @@ public class LevelService {
         );
     }
 
-    // TODO: 난이도 목록 조회
+
+    /**
+     * 난이도 페이지 조회
+     *
+     * @param pageNumber 페이지 번호
+     * @return 조회된 난이도 목록 정보
+     */
+    public LevelPageDto getLevels(int pageNumber) {
+
+        Sort sort = Sort.by(Sort.Direction.DESC, "id");
+        Pageable pageable = PageRequest.of(Math.max(0, pageNumber), LEVELS_PER_PAGE, sort);
+
+        Page<LevelDto> page = levelRepository.findAll(pageable)
+                .map(levelMapper::toLevelDto);
+
+        return new LevelPageDto(page);
+    }
 
 
     /**

--- a/src/main/java/com/upstage/devup/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/upstage/devup/bookmark/repository/BookmarkRepository.java
@@ -19,7 +19,7 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, BookmarkId> 
 
     @Query("""
         SELECT new com.upstage.devup.bookmark.dto.BookmarkDetails(
-                q.id, q.title, c.categoryName, l.level, b.createdAt
+                q.id, q.title, c.categoryName, l.levelName, b.createdAt
                 )
                 FROM Bookmark b
                 JOIN b.question q

--- a/src/main/java/com/upstage/devup/global/entity/Level.java
+++ b/src/main/java/com/upstage/devup/global/entity/Level.java
@@ -25,7 +25,7 @@ public class Level {
             nullable = false,
             length = 50
     )
-    private String level;
+    private String levelName;
 
     @Column(nullable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/com/upstage/devup/global/entity/Level.java
+++ b/src/main/java/com/upstage/devup/global/entity/Level.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name = "levels")
 @Getter
@@ -18,6 +20,15 @@ public class Level {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(unique = true, nullable = false, length = 50)
+    @Column(
+            unique = true,
+            nullable = false,
+            length = 50
+    )
     private String level;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    private LocalDateTime modifiedAt;
 }

--- a/src/main/java/com/upstage/devup/global/entity/Level.java
+++ b/src/main/java/com/upstage/devup/global/entity/Level.java
@@ -1,10 +1,7 @@
 package com.upstage.devup.global.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
@@ -31,4 +28,9 @@ public class Level {
     private LocalDateTime createdAt;
 
     private LocalDateTime modifiedAt;
+
+    public void setLevelName(String levelName) {
+        this.levelName = levelName;
+        this.modifiedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/upstage/devup/question/service/QuestionService.java
+++ b/src/main/java/com/upstage/devup/question/service/QuestionService.java
@@ -87,7 +87,7 @@ public class QuestionService {
                 .title(question.getTitle())
                 .questionText(question.getQuestionText())
                 .category(question.getCategory().getCategoryName())
-                .level(question.getLevel().getLevel())
+                .level(question.getLevel().getLevelName())
                 .isBookmarked(isBookmarked)
                 .createdAt(question.getCreatedAt())
                 .modifiedAt(question.getModifiedAt())

--- a/src/main/java/com/upstage/devup/user/history/dto/UserSolvedHistoryDetailDto.java
+++ b/src/main/java/com/upstage/devup/user/history/dto/UserSolvedHistoryDetailDto.java
@@ -39,7 +39,7 @@ public class UserSolvedHistoryDetailDto {
                 .questionTitle(question.getTitle())
                 .questionText(question.getQuestionText())
                 .category(question.getCategory().getCategoryName())
-                .level(question.getLevel().getLevel())
+                .level(question.getLevel().getLevelName())
                 .userAnswerText(entity.getAnswerText())
                 .solvedAt(entity.getCreatedAt())
                 .isCorrect(entity.getIsCorrect())

--- a/src/main/java/com/upstage/devup/user/history/dto/UserSolvedQuestionDto.java
+++ b/src/main/java/com/upstage/devup/user/history/dto/UserSolvedQuestionDto.java
@@ -32,7 +32,7 @@ public class UserSolvedQuestionDto {
                 .questionId(entity.getQuestion().getId())
                 .questionTitle(entity.getQuestion().getTitle())
                 .category(entity.getQuestion().getCategory().getCategoryName())
-                .level(entity.getQuestion().getLevel().getLevel())
+                .level(entity.getQuestion().getLevel().getLevelName())
                 .solvedAt(entity.getCreatedAt())
                 .isCorrect(entity.getIsCorrect())
                 .build();

--- a/src/main/java/com/upstage/devup/user/wrong/service/UserWrongAnswerQueryService.java
+++ b/src/main/java/com/upstage/devup/user/wrong/service/UserWrongAnswerQueryService.java
@@ -54,7 +54,7 @@ public class UserWrongAnswerQueryService {
                 .questionId(question.getId())
                 .title(question.getTitle())
                 .category(question.getCategory().getCategoryName())
-                .level(question.getLevel().getLevel())
+                .level(question.getLevel().getLevelName())
                 .createdAt(entity.getCreatedAt())
                 .build();
     }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -28,11 +28,11 @@ VALUES
 
 -- 난이도 (levels)
 INSERT INTO levels
-    (id, level)
+    (id, level_name, created_at)
 VALUES
-    (1, 'EASY'),
-    (2, 'MEDIUM'),
-    (3, 'HARD');
+    (1, 'EASY', CURRENT_TIMESTAMP),
+    (2, 'MEDIUM', CURRENT_TIMESTAMP),
+    (3, 'HARD', CURRENT_TIMESTAMP);
 
 -- 권한 (roles)
 INSERT INTO roles

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -29,15 +29,15 @@ ALTER TABLE categories
 
 CREATE TABLE levels
 (
-    id    BIGINT            NOT NULL AUTO_INCREMENT,
-    level VARCHAR(50)       NOT NULL,
+    id          BIGINT      NOT NULL AUTO_INCREMENT,
+    level_name  VARCHAR(50) NOT NULL,
     created_at  TIMESTAMP   NOT NULL COMMENT '등록일',
     modified_at TIMESTAMP   NULL     COMMENT '수정일',
     PRIMARY KEY (id)
 ); -- '난이도'
 
 ALTER TABLE levels
-    ADD CONSTRAINT UQ_level UNIQUE (level);
+    ADD CONSTRAINT UQ_level UNIQUE (level_name);
 
 CREATE TABLE question_stats
 (

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -29,8 +29,10 @@ ALTER TABLE categories
 
 CREATE TABLE levels
 (
-    id    BIGINT      NOT NULL AUTO_INCREMENT,
-    level VARCHAR(50) NOT NULL,
+    id    BIGINT            NOT NULL AUTO_INCREMENT,
+    level VARCHAR(50)       NOT NULL,
+    created_at  TIMESTAMP   NOT NULL COMMENT '등록일',
+    modified_at TIMESTAMP   NULL     COMMENT '수정일',
     PRIMARY KEY (id)
 ); -- '난이도'
 

--- a/src/test/java/com/upstage/devup/admin/level/service/LevelServiceTest.java
+++ b/src/test/java/com/upstage/devup/admin/level/service/LevelServiceTest.java
@@ -19,7 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
@@ -41,6 +41,57 @@ class LevelServiceTest {
                 .createdAt(LocalDateTime.now())
                 .build()
         );
+    }
+
+    @Nested
+    @DisplayName("난이도 단건 조회 테스트")
+    public class SingleQueryTest {
+
+        @Nested
+        @DisplayName("성공 케이스")
+        public class SuccessCases {
+
+            @Test
+            @DisplayName("유효한 난이도 ID를 사용하는 경우 - 난이도 정보를 반환")
+            public void shouldReturnLevelDto_whenLevelIdIsValid() {
+                // given
+                long categoryId = savedLevel.getId();
+                String levelName = savedLevel.getLevelName();
+                LocalDateTime createdAt = savedLevel.getCreatedAt();
+                LocalDateTime modifiedAt = savedLevel.getModifiedAt();
+
+                // when
+                LevelDto result = levelService.getLevel(categoryId);
+
+                // then
+                assertThat(result).isNotNull();
+                assertThat(result.levelId()).isEqualTo(categoryId);
+                assertThat(result.levelName()).isEqualTo(levelName);
+                assertThat(result.createdAt()).isEqualTo(createdAt);
+                assertThat(result.modifiedAt()).isEqualTo(modifiedAt);
+            }
+        }
+
+        @Nested
+        @DisplayName("실패 케이스")
+        public class FailureCases {
+
+            @ParameterizedTest
+            @CsvSource(value = {
+                    "-1",
+                    "0",
+                    "9223372036854775807"
+            })
+            @DisplayName("존재하지 않는 난이도 ID를 사용하는 경우 - EntityNotFoundException 예외 발생")
+            public void shouldThrowEntityNotFoundException_whenLevelIdDoesNotExist(long categoryId) {
+                // given
+
+                // when & then
+                assertThatThrownBy(() ->
+                        levelService.getLevel(categoryId)
+                ).isInstanceOf(EntityNotFoundException.class).hasMessage("존재하지 않는 난이도입니다.");
+            }
+        }
     }
 
     @Nested

--- a/src/test/java/com/upstage/devup/admin/level/service/LevelServiceTest.java
+++ b/src/test/java/com/upstage/devup/admin/level/service/LevelServiceTest.java
@@ -2,6 +2,7 @@ package com.upstage.devup.admin.level.service;
 
 import com.upstage.devup.admin.level.dto.LevelAddRequest;
 import com.upstage.devup.admin.level.dto.LevelDto;
+import com.upstage.devup.admin.level.dto.LevelPageDto;
 import com.upstage.devup.admin.level.dto.LevelUpdateRequest;
 import com.upstage.devup.admin.level.repository.LevelRepository;
 import com.upstage.devup.global.entity.Level;
@@ -90,6 +91,77 @@ class LevelServiceTest {
                 assertThatThrownBy(() ->
                         levelService.getLevel(categoryId)
                 ).isInstanceOf(EntityNotFoundException.class).hasMessage("존재하지 않는 난이도입니다.");
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("난이도 페이지 조회 테스트")
+    public class PageQueryTest {
+
+        @Nested
+        @DisplayName("성공 케이스")
+        public class SuccessCases {
+
+            @Test
+            @DisplayName("유효한 pageNumber를 사용하는 경우 - 조회된 페이지 정보를 반환")
+            public void shouldReturnLevelPageDto_whenPageNumberIsValid() {
+                // given
+                int pageNumber = 0;
+                int pageSize = 10;
+
+                // when
+                LevelPageDto result = levelService.getLevels(pageNumber);
+
+                // then
+                assertThat(result).isNotNull();
+                assertThat(result.getContent()).isNotEmpty();
+                assertThat(result.getNumber()).isEqualTo(pageNumber);
+                assertThat(result.getSize()).isEqualTo(pageSize);
+                assertThat(result.getTotalPages()).isGreaterThan(0);
+                assertThat(result.getTotalElements()).isGreaterThan(0);
+                assertThat(result.isHasPrevious()).isFalse();
+            }
+
+            @Test
+            @DisplayName("pageNumber가 음수인 경우 - 첫 번째 페이지 정보를 반환")
+            public void shouldReturnFirstPageDto_whenPageNumberIsNegative() {
+                // given
+                int pageNumber = -1;
+                int pageSize = 10;
+
+                // when
+                LevelPageDto result = levelService.getLevels(pageNumber);
+
+                // then
+                assertThat(result).isNotNull();
+                assertThat(result.getContent()).isNotEmpty();
+                assertThat(result.getNumber()).isEqualTo(0);
+                assertThat(result.getSize()).isEqualTo(pageSize);
+                assertThat(result.getTotalPages()).isGreaterThan(0);
+                assertThat(result.getTotalElements()).isGreaterThan(0);
+                assertThat(result.isHasPrevious()).isFalse();
+            }
+
+            @Test
+            @DisplayName("pageNumber가 전체 페이지 수보다 큰 경우 - 빈 페이지 정보를 반환")
+            public void shouldReturnEmptyPageDto_whenPageNumberIsGreaterThanTotalPages() {
+                // given
+                int pageNumber = 10_000_000;
+                int pageSize = 10;
+
+                // when
+                LevelPageDto result = levelService.getLevels(pageNumber);
+
+                // then
+                assertThat(result).isNotNull();
+                assertThat(result.getContent()).isEmpty();
+                assertThat(result.getNumber()).isEqualTo(pageNumber);
+                assertThat(result.getSize()).isEqualTo(pageSize);
+                assertThat(result.getTotalPages()).isGreaterThan(0);
+                assertThat(result.getTotalElements()).isGreaterThan(0);
+                assertThat(result.isHasPrevious()).isTrue();
+                assertThat(result.isHasNext()).isFalse();
             }
         }
     }

--- a/src/test/java/com/upstage/devup/admin/level/service/LevelServiceTest.java
+++ b/src/test/java/com/upstage/devup/admin/level/service/LevelServiceTest.java
@@ -2,13 +2,19 @@ package com.upstage.devup.admin.level.service;
 
 import com.upstage.devup.admin.level.dto.LevelAddRequest;
 import com.upstage.devup.admin.level.dto.LevelDto;
+import com.upstage.devup.admin.level.dto.LevelUpdateRequest;
 import com.upstage.devup.admin.level.repository.LevelRepository;
 import com.upstage.devup.global.entity.Level;
 import com.upstage.devup.global.exception.DuplicatedResourceException;
+import com.upstage.devup.global.exception.EntityNotFoundException;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +27,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @SpringBootTest
 @Transactional
 class LevelServiceTest {
+
+    @PersistenceContext
+    private EntityManager em;
 
     @Autowired
     private LevelService levelService;
@@ -85,6 +94,83 @@ class LevelServiceTest {
                 );
 
                 assertThat(exception.getMessage()).isEqualTo("이미 사용중인 난이도입니다.");
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("난이도 수정 테스트")
+    public class UpdateTest {
+
+        @Nested
+        @DisplayName("성공 케이스")
+        public class SuccessCases {
+
+            @Test
+            @DisplayName("유효한 요청인 경우")
+            public void shouldReturnLevelDto_whenRequestIsValid() {
+                // given
+                long levelId = savedLevel.getId();
+                String newLevelName = "수정된 난이도";
+                LocalDateTime createdAt = savedLevel.getCreatedAt();
+                LocalDateTime start = LocalDateTime.now();
+
+                LevelUpdateRequest request = new LevelUpdateRequest(levelId, newLevelName);
+
+                // when
+                LevelDto result = levelService.updateLevel(request);
+
+                // then
+                assertThat(result).isNotNull();
+                assertThat(result.levelId()).isEqualTo(levelId);
+                assertThat(result.levelName()).isEqualTo(newLevelName);
+                assertThat(result.createdAt()).isEqualTo(createdAt);
+                assertThat(result.modifiedAt()).isBetween(start, LocalDateTime.now());
+            }
+        }
+
+        @Nested
+        @DisplayName("실패 케이스")
+        public class FailureCases {
+
+            @Test
+            @DisplayName("이미 사용중인 난이도 이름으로 수정하려는 경우 - DuplicatedResourceException 예외 발생")
+            public void shouldThrowDuplicatedResourceException_whenNewLevelNameIsDuplicated() {
+                // given
+                long levelId = savedLevel.getId();
+                String newLevelName = "등록된 난이도";
+
+                LevelUpdateRequest request = new LevelUpdateRequest(levelId, newLevelName);
+
+                // when & then
+                DuplicatedResourceException exception = assertThrows(
+                        DuplicatedResourceException.class,
+                        () -> levelService.updateLevel(request)
+                );
+
+                assertThat(exception.getMessage()).isEqualTo("이미 사용중인 난이도입니다.");
+            }
+
+            @ParameterizedTest
+            @CsvSource(value = {
+                    "-1",
+                    "0",
+                    "9223372036854775807"
+            })
+            @DisplayName("이미 사용중인 난이도 이름으로 수정하려는 경우 - DuplicatedResourceException 예외 발생")
+            public void shouldThrowEntityNotFoundException_whenLevelDoesNotExist(long levelId) {
+                // given
+                String newLevelName = "수정할 난이도";
+
+                LevelUpdateRequest request = new LevelUpdateRequest(levelId, newLevelName);
+
+                // when & then
+                EntityNotFoundException exception = assertThrows(
+                        EntityNotFoundException.class,
+                        () -> levelService.updateLevel(request)
+                );
+
+                assertThat(exception.getMessage()).isEqualTo("존재하지 않는 난이도입니다.");
             }
         }
     }

--- a/src/test/java/com/upstage/devup/admin/level/service/LevelServiceTest.java
+++ b/src/test/java/com/upstage/devup/admin/level/service/LevelServiceTest.java
@@ -1,0 +1,91 @@
+package com.upstage.devup.admin.level.service;
+
+import com.upstage.devup.admin.level.dto.LevelAddRequest;
+import com.upstage.devup.admin.level.dto.LevelDto;
+import com.upstage.devup.admin.level.repository.LevelRepository;
+import com.upstage.devup.global.entity.Level;
+import com.upstage.devup.global.exception.DuplicatedResourceException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@Transactional
+class LevelServiceTest {
+
+    @Autowired
+    private LevelService levelService;
+
+    @Autowired
+    private LevelRepository levelRepository;
+
+    private Level savedLevel;
+
+    @BeforeEach
+    public void beforeEach() {
+        savedLevel = levelRepository.save(Level.builder()
+                .levelName("등록된 난이도")
+                .createdAt(LocalDateTime.now())
+                .build()
+        );
+    }
+
+    @Nested
+    @DisplayName("난이도 등록 테스트")
+    public class RegistrationTest {
+
+        @Nested
+        @DisplayName("성공 케이스")
+        public class SuccessCases {
+
+            @Test
+            @DisplayName("유효한 요청의 경우")
+            public void shouldReturnLevelDto_whenRequestIsValid() {
+                // given
+                String level = "등록할 난이도";
+                LocalDateTime start = LocalDateTime.now();
+                LevelAddRequest request = new LevelAddRequest(level);
+
+                // when
+                LevelDto result = levelService.addLevel(request);
+
+                // then
+                assertThat(result).isNotNull();
+                assertThat(result.levelId()).isGreaterThan(0L);
+                assertThat(result.levelName()).isEqualTo(level);
+                assertThat(result.createdAt()).isBetween(start, LocalDateTime.now());
+                assertThat(result.modifiedAt()).isNull();
+            }
+        }
+
+        @Nested
+        @DisplayName("실패 케이스")
+        public class FailureCases {
+
+            @Test
+            @DisplayName("이미 사용중인 난이도 이름을 등록하려는 경우 - DuplicatedResourceException 발생")
+            public void shouldThrowDuplicatedResourceException_whenLevelNameIsInUse() {
+                // given
+                String levelName = savedLevel.getLevelName();
+                LevelAddRequest request = new LevelAddRequest(levelName);
+
+                // when
+                DuplicatedResourceException exception = assertThrows(
+                        DuplicatedResourceException.class,
+                        () -> levelService.addLevel(request)
+                );
+
+                assertThat(exception.getMessage()).isEqualTo("이미 사용중인 난이도입니다.");
+            }
+        }
+    }
+}

--- a/src/test/java/com/upstage/devup/question/service/QuestionServiceTest.java
+++ b/src/test/java/com/upstage/devup/question/service/QuestionServiceTest.java
@@ -157,7 +157,7 @@ class QuestionServiceTest {
                 assertThat(result.getTitle()).isEqualTo(question.getTitle());
                 assertThat(result.getQuestionText()).isEqualTo(question.getQuestionText());
                 assertThat(result.getCategory()).isEqualTo(question.getCategory().getCategoryName());
-                assertThat(result.getLevel()).isEqualTo(question.getLevel().getLevel());
+                assertThat(result.getLevel()).isEqualTo(question.getLevel().getLevelName());
                 assertThat(result.isBookmarked()).isFalse();
                 assertThat(result.getCreatedAt()).isEqualTo(question.getCreatedAt());
                 assertThat(result.getModifiedAt()).isNull();
@@ -177,7 +177,7 @@ class QuestionServiceTest {
                 assertThat(result.getTitle()).isEqualTo(question.getTitle());
                 assertThat(result.getQuestionText()).isEqualTo(question.getQuestionText());
                 assertThat(result.getCategory()).isEqualTo(question.getCategory().getCategoryName());
-                assertThat(result.getLevel()).isEqualTo(question.getLevel().getLevel());
+                assertThat(result.getLevel()).isEqualTo(question.getLevel().getLevelName());
                 assertThat(result.isBookmarked()).isFalse();
                 assertThat(result.getCreatedAt()).isEqualTo(question.getCreatedAt());
                 assertThat(result.getModifiedAt()).isNull();
@@ -203,7 +203,7 @@ class QuestionServiceTest {
                 assertThat(result.getTitle()).isEqualTo(question.getTitle());
                 assertThat(result.getQuestionText()).isEqualTo(question.getQuestionText());
                 assertThat(result.getCategory()).isEqualTo(question.getCategory().getCategoryName());
-                assertThat(result.getLevel()).isEqualTo(question.getLevel().getLevel());
+                assertThat(result.getLevel()).isEqualTo(question.getLevel().getLevelName());
                 assertThat(result.isBookmarked()).isTrue();
                 assertThat(result.getCreatedAt()).isEqualTo(question.getCreatedAt());
                 assertThat(result.getModifiedAt()).isNull();


### PR DESCRIPTION
## 작업 내용

### `Level` 엔티티 수정
- 명확하게 난이도를 나타내기 위해 level 속성을 levelName으로 변경
- 등록일(`created_at`)은 null을 허용하지 않음
- 수정일(`modified_at`)은 null을 허용함
- 난이도 수정을 위한 `changeLevelName` 메서드 추가
- `schema.sql`, `ERD(v1.0.4)`에 해당 사항 반영

### 등록 기능 구현
- 신규 난이도 등록 전 중복된 난이도 이름이 있는지 확인
- 난이도 등록 요청용 클래스 `LevelAddRequest` 추가
- 난이도 등록 응답용 클래스 `LevelDto` 추가

### 수정 기능 구현
- 난이도 수정 전 중복된 난이도 이름이 있는지 확인
- 난이도 수정 요청용 클래스 `LevelUpdateRequest` 추가

### 삭제 기능 구현
- `Category` 삭제 테스트와 마찬가지 이유로 외래키로 사용중인 `Level` 엔티티 삭제 케이스는 추후 제작할 예정

### 조회 기능 구현
- 단건, 페이지 조회 기능 총 2가지
- `Page` 객체의 노출을 막기 위해 조회된 페이지 정보를 반환하는 `LevelPageDto` 객체 추가
- 정렬 기준은 `id`
- 정렬방식은 내림차순
- `pageNumber`가 음수인 경우 첫 번째 페이지 정보를 반환
- `pageNumber`가 전체 페이지 수보다 크면 빈 페이지 정보를 반환

### Mapper 클래스 추가
- `LevelDto`와 `Level` 엔티티 간 전환을 위한 `LevelMapper` 클래스 추가


## 예외 처리
- 등록 수정 시 중복된 난이도 이름이 있으면 `DuplicatedResourceException` 예외 발생
- 존재하지 않는 난이도 ID를 사용하는 경우 `EntityNotFoundException` 예외 발생
- 외래키로 사용 중인 난이도를 삭제하려는 경우 `DataIntegrityViolationException` 예외 발생