### PR TITLE
feat: 관리자용 난이도 CRUD API 구현

### DIFF
--- a/src/main/java/com/upstage/devup/admin/level/controller/LevelController.java
+++ b/src/main/java/com/upstage/devup/admin/level/controller/LevelController.java
@@ -74,5 +74,17 @@ public class LevelController {
         );
     }
 
-    // TODO: 삭제
+    /**
+     * 난이도 삭제
+     *
+     * @param levelId 삭제할 난이도 ID
+     * @return 삭제된 난이도 정보
+     */
+    @DeleteMapping("/{levelId}")
+    public ResponseEntity<LevelDto> deleteLevel(@PathVariable @Valid Long levelId) {
+
+        return ResponseEntity.ok(
+                levelService.deleteLevel(levelId)
+        );
+    }
 }

--- a/src/main/java/com/upstage/devup/admin/level/controller/LevelController.java
+++ b/src/main/java/com/upstage/devup/admin/level/controller/LevelController.java
@@ -1,5 +1,6 @@
 package com.upstage.devup.admin.level.controller;
 
+import com.upstage.devup.admin.level.dto.LevelAddRequest;
 import com.upstage.devup.admin.level.dto.LevelDto;
 import com.upstage.devup.admin.level.dto.LevelPageDto;
 import com.upstage.devup.admin.level.service.LevelService;
@@ -44,7 +45,20 @@ public class LevelController {
         );
     }
 
-    // TODO: 등록
+    /**
+     * 신규 난이도 등록
+     *
+     * @param request 등록할 난이도 정보
+     * @return 등록된 난이도 정보
+     */
+    @PostMapping
+    public ResponseEntity<LevelDto> addLevel(@RequestBody @Valid LevelAddRequest request) {
+
+        return ResponseEntity.ok(
+                levelService.addLevel(request)
+        );
+    }
+
     // TODO: 수정
     // TODO: 삭제
 }

--- a/src/main/java/com/upstage/devup/admin/level/controller/LevelController.java
+++ b/src/main/java/com/upstage/devup/admin/level/controller/LevelController.java
@@ -3,6 +3,7 @@ package com.upstage.devup.admin.level.controller;
 import com.upstage.devup.admin.level.dto.LevelAddRequest;
 import com.upstage.devup.admin.level.dto.LevelDto;
 import com.upstage.devup.admin.level.dto.LevelPageDto;
+import com.upstage.devup.admin.level.dto.LevelUpdateRequest;
 import com.upstage.devup.admin.level.service.LevelService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -59,6 +60,19 @@ public class LevelController {
         );
     }
 
-    // TODO: 수정
+    /**
+     * 난이도 정보 수정
+     *
+     * @param request 수정할 난이도 정보
+     * @return 수정된 난이도 정보
+     */
+    @PatchMapping
+    public ResponseEntity<LevelDto> updateLevel(@RequestBody @Valid LevelUpdateRequest request) {
+
+        return ResponseEntity.ok(
+                levelService.updateLevel(request)
+        );
+    }
+
     // TODO: 삭제
 }

--- a/src/main/java/com/upstage/devup/admin/level/controller/LevelController.java
+++ b/src/main/java/com/upstage/devup/admin/level/controller/LevelController.java
@@ -1,0 +1,38 @@
+package com.upstage.devup.admin.level.controller;
+
+import com.upstage.devup.admin.level.dto.LevelDto;
+import com.upstage.devup.admin.level.service.LevelService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin/levels")
+@RequiredArgsConstructor
+public class LevelController {
+
+    private final LevelService levelService;
+
+    /**
+     * 난이도 단건 조회
+     *
+     * @param levelId 조회할 난이도 ID
+     * @return 조회된 난이도 정보
+     */
+    @GetMapping("/{levelId}")
+    public ResponseEntity<LevelDto> getLevel(@PathVariable @Valid Long levelId) {
+
+        return ResponseEntity.ok(
+                levelService.getLevel(levelId)
+        );
+    }
+
+    // TODO: 페이지 조회
+    // TODO: 등록
+    // TODO: 수정
+    // TODO: 삭제
+}

--- a/src/main/java/com/upstage/devup/admin/level/controller/LevelController.java
+++ b/src/main/java/com/upstage/devup/admin/level/controller/LevelController.java
@@ -1,14 +1,12 @@
 package com.upstage.devup.admin.level.controller;
 
 import com.upstage.devup.admin.level.dto.LevelDto;
+import com.upstage.devup.admin.level.dto.LevelPageDto;
 import com.upstage.devup.admin.level.service.LevelService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/admin/levels")
@@ -31,7 +29,21 @@ public class LevelController {
         );
     }
 
-    // TODO: 페이지 조회
+
+    /**
+     * 난이도 페이지 조회
+     *
+     * @param pageNumber 조회할 페이지 번호
+     * @return 조회된 난이도 페이지 정보
+     */
+    @GetMapping
+    public ResponseEntity<LevelPageDto> getLevels(@RequestParam @Valid Integer pageNumber) {
+
+        return ResponseEntity.ok(
+                levelService.getLevels(pageNumber)
+        );
+    }
+
     // TODO: 등록
     // TODO: 수정
     // TODO: 삭제

--- a/src/test/java/com/upstage/devup/Util.java
+++ b/src/test/java/com/upstage/devup/Util.java
@@ -5,6 +5,9 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
@@ -21,5 +24,12 @@ public class Util {
                 null,
                 List.of(new SimpleGrantedAuthority(user.role()))
         ));
+    }
+
+    public static String formatToIsoLocalDateTime(LocalDateTime localDateTime) {
+
+        return localDateTime
+                .truncatedTo(ChronoUnit.SECONDS)
+                .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
     }
 }

--- a/src/test/java/com/upstage/devup/admin/level/controller/LevelControllerTest.java
+++ b/src/test/java/com/upstage/devup/admin/level/controller/LevelControllerTest.java
@@ -1,0 +1,133 @@
+package com.upstage.devup.admin.level.controller;
+
+import com.upstage.devup.Util;
+import com.upstage.devup.admin.level.dto.LevelDto;
+import com.upstage.devup.admin.level.service.LevelService;
+import com.upstage.devup.auth.config.SecurityConfig;
+import com.upstage.devup.auth.config.jwt.JwtTokenProvider;
+import com.upstage.devup.global.exception.EntityNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(LevelController.class)
+@Import(SecurityConfig.class)
+class LevelControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    LevelService levelService;
+
+    private static final long ADMIN_USER_ID = 1L;
+    private static final String ROLE_ADMIN = "ROLE_ADMIN";
+    private static final String URL_TEMPLATE = "/api/admin/levels";
+
+    @Nested
+    @DisplayName("단건 조회 API 테스트")
+    public class SingleQueryApiTest {
+
+        @Nested
+        @DisplayName("성공 케이스")
+        public class SuccessCases {
+
+            @Test
+            @DisplayName("유효한 leverId를 사용하는 경우 - 200 반환")
+            public void shouldReturn200_whenLevelIdIsValid() throws Exception {
+                // given
+                long levelId = 1L;
+                String levelName = "난이도 이름";
+                LocalDateTime createdAt = LocalDateTime.now();
+                LocalDateTime modifiedAt = null;
+
+                when(levelService.getLevel(eq(levelId)))
+                        .thenReturn(new LevelDto(levelId, levelName, createdAt, modifiedAt));
+
+                // when & then
+                mockMvc.perform(get(URL_TEMPLATE + "/" + levelId)
+                                .with(Util.getAuthentication(ADMIN_USER_ID, ROLE_ADMIN)))
+                        .andExpect(status().isOk())
+                        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                        .andExpect(jsonPath("$.levelId").value(levelId))
+                        .andExpect(jsonPath("$.levelName").value(levelName))
+                        .andExpect(jsonPath("$.createdAt").value(Util.formatToIsoLocalDateTime(createdAt)))
+                        .andExpect(jsonPath("$.modifiedAt").value(modifiedAt));
+
+                verify(levelService).getLevel(eq(levelId));
+            }
+        }
+
+        @Nested
+        @DisplayName("실패 케이스")
+        public class FailureCases {
+
+            @Test
+            @DisplayName("로그인하지 않고 호출한 경우 - 401 반환")
+            public void shouldReturn401_whenUserDoesNotSignIn() throws Exception {
+                // given
+                long levelId = 1L;
+
+                // when & then
+                mockMvc.perform(get(URL_TEMPLATE + "/" + levelId))
+                        .andExpect(status().isUnauthorized());
+            }
+
+            @Test
+            @DisplayName("관리자로 로그인하지 않고 호출한 경우 - 403 반환")
+            public void shouldReturn403_whenUserDoesNotSignInToAdmin() throws Exception {
+                // given
+                long levelId = 1L;
+                long userId = 2L;
+
+                // when & then
+                mockMvc.perform(get(URL_TEMPLATE + "/" + levelId)
+                                .with(Util.getAuthentication(userId, "ROLE_USER")))
+                        .andExpect(status().isForbidden());
+            }
+
+            @ParameterizedTest
+            @CsvSource(value = {
+                    "-1",
+                    "0",
+                    "9223372036854775807"
+            })
+            @DisplayName("존재하지 않는 leverId를 사용하는 경우 - 404 반환")
+            public void shouldReturn404_whenLevelIdDoesNotExist(long levelId) throws Exception {
+                // given
+                final String CODE_NOT_FOUND = "NOT_FOUND";
+                final String ERR_MSG = "존재하지 않는 난이도입니다.";
+
+                when(levelService.getLevel(eq(levelId)))
+                        .thenThrow(new EntityNotFoundException(ERR_MSG));
+
+                // when & then
+                mockMvc.perform(get(URL_TEMPLATE + "/" + levelId)
+                                .with(Util.getAuthentication(ADMIN_USER_ID, ROLE_ADMIN)))
+                        .andExpect(status().isNotFound())
+                        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                        .andExpect(jsonPath("$.code").value(CODE_NOT_FOUND))
+                        .andExpect(jsonPath("$.message").value(ERR_MSG));
+
+                verify(levelService).getLevel(eq(levelId));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 작업 내용

### 관리자용 난이도 CRUD API 구현
- 모든 API는 관리자 권한 필요
- 난이도 등록, 수정 정보를 담은 `LevelAddRequest`, `LevelUpdateRequest`를 `record`로 구현
- 테스트 코드 작성 및 통과 확인

### Util 클래스에 `formatToIsoLocalDateTime` 추가
- `LocalDateTime`을 `ISO_LOCAL_DATE_TIME`으로 변경하는 static 메서드
- `Entity`, `DTO`에서는 `@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")`으로 날짜를 포맷팅
- 테스트 코드에서 `LocalDateTime` 객체를 문자열로 비교할 때 포맷 차이로 인한 오류를 방지하기 위해 사용


## API 설명
| 기능 | 메서드 | API |
|---|---|---|
| 단건 조회 | `GET` | `/api/admin/levels/{levelId}`|
| 페이지 조회 | `GET` | `/api/admin/levels?pageNumber=0`|
| 등록 | `POST` | `/api/admin/levels`|
| 수정 | `PATCH` | `/api/admin/levels`|
| 삭제 | `DELETE` | `/api/admin/levels/{levelId}`|